### PR TITLE
Remove Minerals Dependency

### DIFF
--- a/TwitchySharp.Api/Helix/Conduits/Enums/ConduitShardStatus.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Enums/ConduitShardStatus.cs
@@ -1,53 +1,58 @@
-﻿namespace TwitchySharp.Api.Helix.Conduits;
+﻿using System.Text.Json.Serialization;
+using TwitchySharp.Helpers;
+
+namespace TwitchySharp.Api.Helix.Conduits;
 
 /// <summary>
-/// Represents the status of a conduit shard.
+/// Contains static definitions that represent the status of a conduit shard.
 /// </summary>
-public enum ConduitShardStatus
+[JsonConverter(typeof(ValueBackedEnumJsonConverter<ConduitShardStatus, string>))]
+public record ConduitShardStatus(string Value)
+    : ValueBackedEnum<string>(Value)
 {
     /// <summary>
     /// The shard is enabled and working.
     /// </summary>
-    Enabled,
+    public static ConduitShardStatus Enabled { get; } = new("enabled");
     /// <summary>
     /// The shard is pending verification of the specified callback URL.
     /// </summary>
-    WebhookCallbackVerificationPending,
+    public static ConduitShardStatus WebhookCallbackVerificationPending { get; } = new("webhook_callback_verification_pending");
     /// <summary>
     /// The specified callback URL failed verification.
     /// </summary>
-    WebhookCallbackVerificationFailed,
+    public static ConduitShardStatus WebhookCallbackVerificationFailed { get; } = new("webhook_callback_verification_failed");
     /// <summary>
     /// The notification delivery failure rate was too high.
     /// </summary>
-    NotificationFailuresExceeded,
+    public static ConduitShardStatus NotificationFailuresExceeded { get; } = new("notification_failures_exceeded");
     /// <summary>
     /// The client closed the connection.
     /// </summary>
-    WebsocketDisconnected,
+    public static ConduitShardStatus WebsocketDisconnected { get; } = new("websocket_disconnected");
     /// <summary>
     /// The client failed to respond to a ping message.
     /// </summary>
-    WebsocketFailedPingPong,
+    public static ConduitShardStatus WebsocketFailedPingPong { get; } = new("websocket_failed_ping_pong");
     /// <summary>
     /// The client sent a non-pong message. 
     /// Clients may only send pong messages (and only in response to a ping message).
     /// </summary>
-    WebsocketReceivedInboundTraffic,
+    public static ConduitShardStatus WebsocketReceivedInboundTraffic { get; } = new("websocket_received_inbound_traffic");
     /// <summary>
     /// The Twitch WebSocket server experienced an unexpected error.
     /// </summary>
-    WebsocketInternalError,
+    public static ConduitShardStatus WebsocketInternalError { get; } = new("websocket_internal_error");
     /// <summary>
     /// The Twitch WebSocket server timed out writing the message to the client.
     /// </summary>
-    WebsocketNetworkTimeout,
+    public static ConduitShardStatus WebsocketNetworkTimeout { get; } = new("websocket_network_timeout");
     /// <summary>
     /// The Twitch WebSocket server experienced a network error writing the message to the client.
     /// </summary>
-    WebsocketNetworkError,
+    public static ConduitShardStatus WebsocketNetworkError { get; } = new("websocket_network_error");
     /// <summary>
     /// The client failed to reconnect to the Twitch WebSocket server within the required time after a Reconnect Message.
     /// </summary>
-    WebsocketFailedToReconnect
+    public static ConduitShardStatus WebsocketFailedToReconnect { get; } = new("websocket_failed_to_reconnect");
 }

--- a/TwitchySharp.Api/Helix/Conduits/Models/ConduitShard.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Models/ConduitShard.cs
@@ -16,7 +16,6 @@ public record ConduitShard
     /// The shard status.
     /// The subscriber receives events only for <see cref="ConduitShardStatus.Enabled"/> shards. 
     /// </summary>
-    [JsonConverter(typeof(SnakeCaseLowerJsonStringEnumConverter<ConduitShardStatus>))]
     public required ConduitShardStatus Status { get; init; }
     /// <summary>
     /// The transport details used to send the notifications.

--- a/TwitchySharp.Api/Helix/Conduits/Requests/GetConduitShardsRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Requests/GetConduitShardsRequest.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using TwitchySharp.Helpers;
 using TwitchySharp.Api.Models;
-using Minerals.StringCases;
 
 namespace TwitchySharp.Api.Helix.Conduits;
 /// <summary>
@@ -35,7 +34,7 @@ public class GetConduitShardsRequest(
         "/eventsub/conduits/shards" +
         new HttpQueryParameters()
             .Add("conduit_id", conduitId)
-            .Add("status", status?.ToString().ToSnakeCase())
+            .Add("status", status?.Value)
             .Add("after", after),
         clientId,
         accessToken

--- a/TwitchySharp.Api/Helix/EventSub/Enums/EventSubSubscriptionStatus.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Enums/EventSubSubscriptionStatus.cs
@@ -1,77 +1,86 @@
-﻿namespace TwitchySharp.Api.Helix.EventSub;
+﻿using System.Text.Json.Serialization;
+using TwitchySharp.Helpers;
 
-public enum EventSubSubscriptionStatus
+namespace TwitchySharp.Api.Helix.EventSub;
+
+/// <summary>
+/// Contains static definitions for various EventSub subscription states.
+/// </summary>
+/// <param name="Value"></param>
+[JsonConverter(typeof(ValueBackedEnumJsonConverter<EventSubSubscriptionStatus, string>))]
+public record EventSubSubscriptionStatus(string Value)
+    : ValueBackedEnum<string>(Value)
 {
     /// <summary>
     /// The subscription is enabled.
     /// </summary>
-    Enabled,
+    public static EventSubSubscriptionStatus Enabled { get; } = new("enabled");
     /// <summary>
     /// The subscription is pending verification of the specified callback URL.
     /// </summary>
-    WebhookCallbackVerificationPending,
+    public static EventSubSubscriptionStatus WebhookCallbackVerificationPending { get; } = new("webhook_callback_verification_pending");
     /// <summary>
     /// The specified callback URL failed verification.
     /// </summary>
-    WebhookCallbackVerificationFailed,
+    public static EventSubSubscriptionStatus WebhookCallbackVerificationFailed { get; } = new("webhook_callback_verification_failed");
     /// <summary>
     /// The notification delivery failure rate was too high.
     /// </summary>
-    NotificationFailuresExceeded,
+    public static EventSubSubscriptionStatus NotificationFailuresExceeded { get; } = new("notification_failures_exceeded");
     /// <summary>
     /// The authorization was revoked for one or more users specified in the Condition object.
     /// </summary>
-    AuthorizationRevoked,
+    public static EventSubSubscriptionStatus AuthorizationRevoked { get; } = new("authorization_revoked");
     /// <summary>
     /// The moderator that authorized the subscription is no longer one of the broadcaster's moderators.
     /// </summary>
-    ModeratorRemoved,
+    public static EventSubSubscriptionStatus ModeratorRemoved { get; } = new("moderator_removed");
     /// <summary>
     /// One of the users specified in the Condition object was removed.
     /// </summary>
-    UserRemoved,
+    public static EventSubSubscriptionStatus UserRemoved { get; } = new("user_removed");
     /// <summary>
     /// The user specified in the Condition object was banned from the broadcaster's chat.
     /// </summary>
-    ChatUserBanned,
+    public static EventSubSubscriptionStatus ChatUserBanned { get; } = new("chat_user_banned");
     /// <summary>
     /// The subscription to subscription type and version is no longer supported.
     /// </summary>
-    VersionRemoved,
+    public static EventSubSubscriptionStatus VersionRemoved { get; } = new("version_removed");
     /// <summary>
     /// The subscription to the beta subscription type was removed due to maintenance.
     /// </summary>
-    BetaMaintenance,
+    public static EventSubSubscriptionStatus BetaMaintenance { get; } = new("beta_maintenance");
     /// <summary>
     /// The client closed the connection.
     /// </summary>
-    WebsocketDisconnected,
+    public static EventSubSubscriptionStatus WebsocketDisconnected { get; } = new("websocket_disconnected");
     /// <summary>
     /// The client failed to respond to a ping message.
     /// </summary>
-    WebsocketFailedPingPong,
+    public static EventSubSubscriptionStatus WebsocketFailedPingPong { get; } = new("websocket_failed_ping_pong");
     /// <summary>
     /// The client sent a non-pong message. Clients may only send pong messages (and only in response to a ping message).
     /// </summary>
-    WebsocketReceivedInboundTraffic,
+    public static EventSubSubscriptionStatus WebsocketReceivedInboundTraffic { get; } = new("websocket_received_inbound_traffic");
     /// <summary>
     /// The client failed to subscribe to events within the required time.
     /// </summary>
-    WebsocketConnectionUnused,
+    public static EventSubSubscriptionStatus WebsocketConnectionUnused { get; } = new("websocket_connection_unused");
     /// <summary>
     /// The Twitch WebSocket server experienced an unexpected error.
     /// </summary>
-    WebsocketInternalError,
+    public static EventSubSubscriptionStatus WebsocketInternalError { get; } = new("websocket_internal_error");
     /// <summary>
     /// The Twitch WebSocket server timed out writing the message to the client.
     /// </summary>
-    WebsocketNetworkTimeout,
+    public static EventSubSubscriptionStatus WebsocketNetworkTimeout { get; } = new("websocket_network_timeout");
     /// <summary>
     /// The Twitch WebSocket server experienced a network error writing the message to the client.
     /// </summary>
-    WebsocketNetworkError,
+    public static EventSubSubscriptionStatus WebsocketNetworkError { get; } = new("websocket_network_error");
     /// <summary>
     /// The client failed to reconnect to the Twitch WebSocket server within the required time after a Reconnect Message.
     /// </summary>
-    WebsocketFailedToReconnect
+    public static EventSubSubscriptionStatus WebsocketFailedToReconnect { get; } = new("websocket_failed_to_reconnect");
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
@@ -18,7 +18,6 @@ public record EventSubSubscription
     /// The subscription's status.
     /// Note that the subscriber receives events only for <see cref="EventSubSubscriptionStatus.Enabled"/> subscriptions.
     /// </summary>
-    [JsonConverter(typeof(SnakeCaseLowerJsonStringEnumConverter<EventSubSubscriptionStatus>))]
     public required EventSubSubscriptionStatus Status { get; init; }
     /// <summary>
     /// The subscription’s type name.

--- a/TwitchySharp.Api/Helix/EventSub/Requests/GetEventSubSubscriptionsRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Requests/GetEventSubSubscriptionsRequest.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Minerals.StringCases;
 using TwitchySharp.Helpers;
 using TwitchySharp.Api.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub;
 /// <summary>
 /// Gets a list of EventSub subscriptions that the <paramref name="clientId"/> created.
+/// <br/>
+/// See <see href="https://dev.twitch.tv/docs/api/reference/#get-eventsub-subscriptions">Get EventSub Subscriptions</see> for more information.
 /// </summary>
 /// <remarks>
 /// If using <see cref="WebhookSubscriptionTransport"/> or <see cref="ConduitSubscriptionTransport"/>, requires an app access token.
@@ -43,7 +44,7 @@ public class GetEventSubSubscriptionsRequest(
     : HelixApiRequest<GetEventSubSubscriptionsResponse>(
         "/eventsub/subscriptions" +
         new HttpQueryParameters()
-            .Add("status", status?.ToString().ToSnakeCase())
+            .Add("status", status?.Value)
             .Add("type", type?.Type)
             .Add("user_id", userId)
             .Add("after", after),

--- a/TwitchySharp.Api/TwitchySharp.Api.csproj
+++ b/TwitchySharp.Api/TwitchySharp.Api.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.1.2" />
-    <PackageReference Include="Minerals.StringCases" Version="0.2.1" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Refactor certain enums to allow for removal of the Minerals.StringCases dependency.