### PR TITLE
Add ASP.NET Core Extensions Project for Webhook Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Expect breaking changes.
     - [ ] User 
 - [X] Websockets Notification Handler
 - [X] Webhooks Notification Handler
-- [ ] ASP.NET Core Integration
+- [X] ASP.NET Core Integration
 
 ### Documentation
 - [ ] API Example Project

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/EventSubWebhookRequestHeaderExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/EventSubWebhookRequestHeaderExtensions.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration;
+
+internal static class EventSubWebhookRequestHeaderExtensions
+{
+    public static IHeaderDictionary ToHeaderDictionary(this EventSubWebhookRequestHeader header)
+        => new HeaderDictionary
+        {
+            { "Twitch-Eventsub-Message-Id", header.TwitchEventsubMessageId },
+            { "Twitch-Eventsub-Message-Retry", header.TwitchEventsubMessageRetry ?? string.Empty },
+            { "Twitch-Eventsub-Message-Type", header.TwitchEventsubMessageType },
+            { "Twitch-Eventsub-Message-Signature", header.TwitchEventsubMessageSignature },
+            { "Twitch-Eventsub-Message-Timestamp",  header.TwitchEventsubMessageTimestamp },
+            { "Twitch-Eventsub-Subscription-Type", header.TwitchEventsubSubscriptionType },
+            { "Twitch-Eventsub-Subscription-Version", header.TwitchEventsubSubscriptionVersion }
+        };
+}
+
+internal static class HttpRequestMessageExtensions
+{
+    public static HttpRequestMessage AddHeaders(this HttpRequestMessage request, IHeaderDictionary headers)
+    {
+        foreach (var header in headers)
+        {
+            request.Headers.TryAddWithoutValidation(header.Key, [.. header.Value]);
+        }
+        return request;
+    }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -8,6 +8,7 @@ using System.Text;
 using TwitchySharp.EventSub.Notifications;
 using TwitchySharp.EventSub.Notifications.Channel;
 using TwitchySharp.EventSub.Webhooks.SignatureComputers;
+using TwitchySharp.Shared.EventSub.Enums;
 
 namespace TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration;
 
@@ -183,7 +184,71 @@ public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
     [Fact]
     public async Task Respond_ValidRevocationRequest_204Response()
     {
-        throw new NotImplementedException();
+        const string FAKE_SUBSCRIPTION_ID = "f1c2a387-161a-49f9-a165-0f21d7a4e1c4";
+        const string FAKE_MESSAGE_ID = "1234567890";
+        const string FAKE_TIMESTAMP = "2019-11-16T10:11:12.634234626Z";
+        const string FAKE_BODY = $$"""
+            {
+              "subscription": {
+                "id": "{{FAKE_SUBSCRIPTION_ID}}",
+                "status": "authorization_revoked",
+                "type": "channel.follow",
+                "cost": 1,
+                "version": "1",
+                "condition": {
+                  "broadcaster_user_id": "12826"
+                },
+                "transport": {
+                  "method": "webhook",
+                  "callback": "https://example.com/webhooks/callback"
+                },
+                "created_at": "{{FAKE_TIMESTAMP}}"
+              }
+            }
+            """;
+
+        DefaultTwitchWebhookCrypto stubCrypto = new();
+        string fakeSignature = Encoding.UTF8.GetString(await stubCrypto.ComputeSignature(Encoding.UTF8.GetBytes(_fixture.Secret), FAKE_MESSAGE_ID, FAKE_TIMESTAMP, FAKE_BODY));
+
+        IHeaderDictionary fakeHeaders = new EventSubWebhookRequestHeader()
+        {
+            TwitchEventsubMessageId = FAKE_MESSAGE_ID,
+            TwitchEventsubMessageType = "revocation",
+            TwitchEventsubMessageSignature = fakeSignature,
+            TwitchEventsubMessageTimestamp = FAKE_TIMESTAMP,
+            TwitchEventsubSubscriptionType = "channel.follow",
+            TwitchEventsubSubscriptionVersion = "1"
+        }.ToHeaderDictionary();
+
+        HttpRequestMessage fakeRevocationRequest = new HttpRequestMessage(HttpMethod.Post, _fixture.Path)
+        {
+            Content = new StringContent(FAKE_BODY)
+        }.AddHeaders(fakeHeaders);
+
+        EventSubSubscription fakePreexistingSubscription = new()
+        {
+            Id = FAKE_SUBSCRIPTION_ID,
+            Cost = 1,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Status = EventSubSubscriptionStatus.Enabled,
+            Transport = new()
+            {
+                Method = EventSubTransportMethod.Webhook,
+                Callback = "https://example.com/webhooks/callback"
+            },
+            Type = "channel.follow",
+            Version = "1"
+        };
+        _fixture.Handler.ActiveSubscription = fakePreexistingSubscription;
+
+        HttpClient stubClient = _fixture.CreateClient();
+        HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeRevocationRequest);
+        EventSubSubscription? actualSubscription = _fixture.Handler.ActiveSubscription;
+
+        HttpStatusCode actualResponseStatusCode = actualReponse.StatusCode;
+
+        Assert.Equal(HttpStatusCode.NoContent, actualResponseStatusCode);
+        Assert.Null(actualSubscription);
     }
 
     [Fact]

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -296,6 +296,8 @@ public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
             Content = new StringContent(FAKE_BODY)
         }.AddHeaders(fakeHeaders);
 
+        _fixture.Handler.LastNotification = null; // leaky handler.
+
         HttpClient stubClient = _fixture.CreateClient();
         HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeInvalidSecretRequest);
 

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -273,6 +273,36 @@ public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
     [Fact]
     public async Task Respond_InvalidSecretRequest_401Response()
     {
-        throw new NotImplementedException();
+        const string FAKE_MESSAGE_ID = "1234567890";
+        const string FAKE_TIMESTAMP = "2023-11-06T18:11:47.492253549Z";
+        const string FAKE_BODY = "{}";
+        const string FAKE_INVALID_SECRET = "bad_secret";
+
+        DefaultTwitchWebhookCrypto stubCrypto = new();
+        string fakeSignature = Encoding.UTF8.GetString(await stubCrypto.ComputeSignature(Encoding.UTF8.GetBytes(FAKE_INVALID_SECRET), FAKE_MESSAGE_ID, FAKE_TIMESTAMP, FAKE_BODY));
+
+        IHeaderDictionary fakeHeaders = new EventSubWebhookRequestHeader()
+        {
+            TwitchEventsubMessageId = FAKE_MESSAGE_ID,
+            TwitchEventsubMessageType = "notification",
+            TwitchEventsubMessageSignature = fakeSignature,
+            TwitchEventsubMessageTimestamp = FAKE_TIMESTAMP,
+            TwitchEventsubSubscriptionType = "channel.follow",
+            TwitchEventsubSubscriptionVersion = "1"
+        }.ToHeaderDictionary();
+
+        HttpRequestMessage fakeInvalidSecretRequest = new HttpRequestMessage(HttpMethod.Post, _fixture.Path)
+        {
+            Content = new StringContent(FAKE_BODY)
+        }.AddHeaders(fakeHeaders);
+
+        HttpClient stubClient = _fixture.CreateClient();
+        HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeInvalidSecretRequest);
+
+        HttpStatusCode actualResponseStatusCode = actualReponse.StatusCode;
+        IEventSubNotification? actualNotification = _fixture.Handler.LastNotification;
+
+        Assert.Equal(HttpStatusCode.Unauthorized, actualResponseStatusCode);
+        Assert.Null(actualNotification);
     }
 }

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestPlatform.TestHost;
 using System.Net;
 using System.Text;
 using TwitchySharp.EventSub.Notifications;
+using TwitchySharp.EventSub.Notifications.Channel;
 using TwitchySharp.EventSub.Webhooks.SignatureComputers;
 
 namespace TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration;
@@ -77,7 +78,106 @@ public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
     [Fact]
     public async Task Respond_ValidChannelChatMessageNotification_200Response()
     {
-        throw new NotImplementedException();
+        const string FAKE_SUBSCRIPTION_ID = "0b7f3361-672b-4d39-b307-dd5b576c9b27";
+        const string FAKE_MESSAGE_ID = "1234567890";
+        const string FAKE_TIMESTAMP = "2023-11-06T18:11:47.492253549Z";
+        const string FAKE_MESSAGE = "Whaddup chat? Check out Yoyoyopo5 on Twitch, it's good.";
+        const string FAKE_BODY = $$"""
+            {
+              "subscription": {
+                "id": "{{FAKE_SUBSCRIPTION_ID}}",
+                "status": "enabled",
+                "type": "channel.chat.message",
+                "version": "1",
+                "condition": {
+                  "broadcaster_user_id": "1971641",
+                  "user_id": "2914196"
+                },
+                "transport": {
+                  "method": "websocket",
+                  "session_id": "AgoQHR3s6Mb4T8GFB1l3DlPfiRIGY2VsbC1h"
+                },
+                "created_at": "{{FAKE_TIMESTAMP}}",
+                "cost": 0
+              },
+              "event": {
+                "broadcaster_user_id": "1971641",
+                "broadcaster_user_login": "streamer",
+                "broadcaster_user_name": "streamer",
+                "chatter_user_id": "4145994",
+                "chatter_user_login": "viewer32",
+                "chatter_user_name": "viewer32",
+                "message_id": "cc106a89-1814-919d-454c-f4f2f970aae7",
+                "message": {
+                  "text": "{{FAKE_MESSAGE}}",
+                  "fragments": [
+                    {
+                      "type": "text",
+                      "text": "{{FAKE_MESSAGE}}",
+                      "cheermote": null,
+                      "emote": null,
+                      "mention": null
+                    }
+                  ]
+                },
+                "color": "#00FF7F",
+                "badges": [
+                  {
+                    "set_id": "moderator",
+                    "id": "1",
+                    "info": ""
+                  },
+                  {
+                    "set_id": "subscriber",
+                    "id": "12",
+                    "info": "16"
+                  },
+                  {
+                    "set_id": "sub-gifter",
+                    "id": "1",
+                    "info": ""
+                  }
+                ],
+                "message_type": "text",
+                "cheer": null,
+                "reply": null,
+                "channel_points_custom_reward_id": null,
+                "source_broadcaster_user_id": null,
+                "source_broadcaster_user_login": null,
+                "source_broadcaster_user_name": null,
+                "source_message_id": null,
+                "source_badges": null
+              }
+            }
+            """;
+
+        DefaultTwitchWebhookCrypto stubCrypto = new();
+        string fakeSignature = Encoding.UTF8.GetString(await stubCrypto.ComputeSignature(Encoding.UTF8.GetBytes(_fixture.Secret), FAKE_MESSAGE_ID, FAKE_TIMESTAMP, FAKE_BODY));
+
+        IHeaderDictionary fakeHeaders = new EventSubWebhookRequestHeader()
+        {
+            TwitchEventsubMessageId = FAKE_MESSAGE_ID,
+            TwitchEventsubMessageType = "notification",
+            TwitchEventsubMessageSignature = fakeSignature,
+            TwitchEventsubMessageTimestamp = FAKE_TIMESTAMP,
+            TwitchEventsubSubscriptionType = "channel.chat.message",
+            TwitchEventsubSubscriptionVersion = "1"
+        }.ToHeaderDictionary();
+
+        HttpRequestMessage fakeNotificationRequest = new HttpRequestMessage(HttpMethod.Post, _fixture.Path)
+        {
+            Content = new StringContent(FAKE_BODY)
+        }.AddHeaders(fakeHeaders);
+
+        HttpClient stubClient = _fixture.CreateClient();
+        HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeNotificationRequest);
+        ChannelChatMessageNotification? actualNotification = _fixture.Handler.LastNotification as ChannelChatMessageNotification;
+
+        HttpStatusCode actualResponseStatusCode = actualReponse.StatusCode;
+
+        Assert.Equal(HttpStatusCode.OK, actualResponseStatusCode);
+        Assert.NotNull(actualNotification);
+        Assert.Equal(FAKE_MESSAGE, actualNotification.Event.Message.Text);
     }
 
     [Fact]

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -1,0 +1,100 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+using System.Net;
+using System.Text;
+using TwitchySharp.EventSub.Notifications;
+using TwitchySharp.EventSub.Webhooks.SignatureComputers;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration;
+
+public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
+    : IClassFixture<WebhooksFixture>
+{
+    private readonly WebhooksFixture _fixture = fixture;
+
+    [Fact]
+    public async Task Respond_ValidCallbackRequest_ValidResponse()
+    {
+        const string FAKE_SUBSCRIPTION_ID = "f1c2a387-161a-49f9-a165-0f21d7a4e1c4";
+        const string FAKE_CHALLENGE = "test_challenge";
+        const string FAKE_MESSAGE_ID = "1234567890";
+        const string FAKE_TIMESTAMP = "2019-11-16T10:11:12.634234626Z";
+        const string FAKE_BODY = $$"""
+            {
+              "challenge": "{{FAKE_CHALLENGE}}",
+              "subscription": {
+                "id": "{{FAKE_SUBSCRIPTION_ID}}",
+                "status": "webhook_callback_verification_pending",
+                "type": "channel.follow",
+                "version": "1",
+                "cost": 1,
+                "condition": {
+                  "broadcaster_user_id": "12826"
+                },
+                "transport": {
+                  "method": "webhook",
+                  "callback": "http://localhost/test-webhook"
+                },
+                "created_at": "2019-11-16T10:11:12.634234626Z"
+              }
+            }
+            """;
+
+        DefaultTwitchWebhookCrypto stubCrypto = new();
+        string fakeSignature = Encoding.UTF8.GetString(await stubCrypto.ComputeSignature(Encoding.UTF8.GetBytes(_fixture.Secret), FAKE_MESSAGE_ID, FAKE_TIMESTAMP, FAKE_BODY));
+
+        IHeaderDictionary fakeHeaders = new EventSubWebhookRequestHeader()
+        {
+            TwitchEventsubMessageId = FAKE_MESSAGE_ID,
+            TwitchEventsubMessageType = "webhook_callback_verification",
+            TwitchEventsubMessageSignature = fakeSignature,
+            TwitchEventsubMessageTimestamp = FAKE_TIMESTAMP,
+            TwitchEventsubSubscriptionType = "channel.follow",
+            TwitchEventsubSubscriptionVersion = "1"
+        }.ToHeaderDictionary();
+
+        HttpRequestMessage fakeCallbackRequest = new HttpRequestMessage(HttpMethod.Post, _fixture.Path)
+        {
+            Content = new StringContent(FAKE_BODY)
+        }.AddHeaders(fakeHeaders);
+
+        HttpClient stubClient = _fixture.CreateClient();
+        HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeCallbackRequest);
+        EventSubSubscription? actualSubscription = _fixture.Handler.ActiveSubscription;
+
+        HttpStatusCode actualResponseStatusCode = actualReponse.StatusCode;
+        string actualResponseBody = await actualReponse.Content.ReadAsStringAsync();
+
+        Assert.Equal(HttpStatusCode.OK, actualResponseStatusCode);
+        Assert.Equal(FAKE_CHALLENGE, actualResponseBody);
+        Assert.NotNull(actualSubscription);
+        Assert.Equal(FAKE_SUBSCRIPTION_ID, actualSubscription.Id);
+    }
+
+    [Fact]
+    public async Task Respond_ValidChannelChatMessageNotification_200Response()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Respond_ValidRevocationRequest_204Response()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Respond_InvalidHeadersRequest_400Response()
+    {
+        throw new NotImplementedException();
+    }
+
+    [Fact]
+    public async Task Respond_InvalidSecretRequest_401Response()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/Test_TwitchWebhooksRouteExtensions.cs
@@ -254,7 +254,20 @@ public class Test_TwitchWebhooksRouteExtensions(WebhooksFixture fixture)
     [Fact]
     public async Task Respond_InvalidHeadersRequest_400Response()
     {
-        throw new NotImplementedException();
+        HeaderDictionary fakeInvalidHeaders = new()
+        {
+            ["Invalid-Message-Id"] = "12345"
+        };
+
+        HttpRequestMessage fakeInvalidRequest = new HttpRequestMessage(HttpMethod.Post, _fixture.Path)
+        {
+            Content = new StringContent("{}")
+        }.AddHeaders(fakeInvalidHeaders);
+
+        HttpClient stubClient = _fixture.CreateClient();
+        HttpResponseMessage actualReponse = await stubClient.SendAsync(fakeInvalidRequest);
+
+        Assert.Equal(HttpStatusCode.BadRequest, actualReponse.StatusCode);
     }
 
     [Fact]

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration.csproj
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<PreserveCompilationContext>true</PreserveCompilationContext>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.22" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TwitchySharp.EventSub.Webhooks.AspNetCore\TwitchySharp.EventSub.Webhooks.AspNetCore.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/WebhooksFixture.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/WebhooksFixture.cs
@@ -65,8 +65,8 @@ public class WebhooksFixture : WebApplicationFactory<Program>
 
 public class TestHandler : IWebhookEventSubHandler
 {
-    public EventSubSubscription? ActiveSubscription { get; private set; }
-    public IEventSubNotification? LastNotification { get; private set; }
+    public EventSubSubscription? ActiveSubscription { get; set; }
+    public IEventSubNotification? LastNotification { get; set; }
 
     public ValueTask OnNotified(IEventSubNotification notification, CancellationToken ct = default)
     {

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/WebhooksFixture.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration/WebhooksFixture.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestPlatform.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchySharp.EventSub.Notifications;
+using TwitchySharp.EventSub.Webhooks.Responses;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.TestHost;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration;
+
+public class Program { }
+
+public class WebhooksFixture : WebApplicationFactory<Program>
+{
+    private const string FAKE_SECRET = "super_secure_secret";
+    private const string FAKE_PATH = "/test-webhooks";
+    public TestHandler Handler => Services.GetRequiredService<IWebhookEventSubHandler>() as TestHandler ?? throw new InvalidOperationException("The IWebhookEventSubHandler is not registered as TestHandler.");
+    public string Secret => Services.GetRequiredService<IConfiguration>().GetRequiredSection("TwitchWebhooks").GetValue<string>("Secret") ?? string.Empty;
+    public string Path => Services.GetRequiredService<IConfiguration>().GetRequiredSection("TwitchWebhooks").GetValue<string>("Path") ?? string.Empty;
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((ctx, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    { "TwitchWebhooks:Secret", FAKE_SECRET },
+                    { "TwitchWebhooks:Path", FAKE_PATH }
+                });
+        });
+        builder.ConfigureServices((ctx, s) =>
+        {
+            s.AddSingleton<IWebhookEventSubHandler, TestHandler>();
+            s.AddTwitchEventSubWebhooksVerification(options =>
+            {
+                options.Secret = ctx.Configuration.GetRequiredSection("TwitchWebhooks").GetValue<string>("Secret") ?? string.Empty;
+            });
+            s.AddTwitchEventSubWebhooks();
+        });
+        builder.Configure(app =>
+        {
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapTwitchWebhooks(app.ApplicationServices.GetRequiredService<IConfiguration>().GetRequiredSection("TwitchWebhooks").GetValue<string>("Path") ?? "/");
+            });
+        });
+    }
+
+    protected override IHostBuilder? CreateHostBuilder()
+        => Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder.UseTestServer();
+            });
+}
+
+public class TestHandler : IWebhookEventSubHandler
+{
+    public EventSubSubscription? ActiveSubscription { get; private set; }
+    public IEventSubNotification? LastNotification { get; private set; }
+
+    public ValueTask OnNotified(IEventSubNotification notification, CancellationToken ct = default)
+    {
+        LastNotification = notification;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask OnSubscriptionRevoked(EventSubSubscription revokedSubscription, CancellationToken ct = default)
+    {
+        if (ActiveSubscription is null)
+            return ValueTask.CompletedTask;
+        if (ActiveSubscription.Id == revokedSubscription.Id)
+            ActiveSubscription = null;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask OnCallbackVerification(EventSubSubscription newSubscription, string challenge, CancellationToken ct = default)
+    {
+        ActiveSubscription = newSubscription;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/DefaultTwitchWebhooksHeaderConverter.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/DefaultTwitchWebhooksHeaderConverter.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+internal class DefaultTwitchWebhooksHeaderConverter : ITwitchWebhooksHeaderConverter
+{
+    private static IEnumerable<string> RequiredHeaders { get; } = [
+        "Twitch-Eventsub-Message-Id",
+        "Twitch-Eventsub-Message-Type",
+        "Twitch-Eventsub-Message-Signature",
+        "Twitch-Eventsub-Message-Timestamp",
+        "Twitch-Eventsub-Subscription-Type",
+        "Twitch-Eventsub-Subscription-Version"
+        ];
+    public TwitchWebhooksRequestHeaderConversionResult Convert(IHeaderDictionary headers)
+        => new()
+            {
+                MissingHeaders = RequiredHeaders.Where(headerName => !headers.ContainsKey(headerName)),
+                ConvertedHeader = new()
+                {
+                    TwitchEventsubMessageId = headers["Twitch-Eventsub-Message-Id"].FirstOrDefault() ?? string.Empty,
+                    TwitchEventsubMessageRetry = headers["Twitch-Eventsub-Message-Retry"].FirstOrDefault(),
+                    TwitchEventsubMessageType = headers["Twitch-Eventsub-Message-Type"].FirstOrDefault() ?? string.Empty,
+                    TwitchEventsubMessageSignature = headers["Twitch-Eventsub-Message-Signature"].FirstOrDefault() ?? string.Empty,
+                    TwitchEventsubMessageTimestamp = headers["Twitch-Eventsub-Message-Timestamp"].FirstOrDefault() ?? string.Empty,
+                    TwitchEventsubSubscriptionType = headers["Twitch-Eventsub-Subscription-Type"].FirstOrDefault() ?? string.Empty,
+                    TwitchEventsubSubscriptionVersion = headers["Twitch-Eventsub-Subscription-Version"].FirstOrDefault() ?? string.Empty
+                }
+            };
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/ITwitchWebhooksHeaderConverter.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/ITwitchWebhooksHeaderConverter.cs
@@ -1,0 +1,8 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+internal interface ITwitchWebhooksHeaderConverter
+{
+    public TwitchWebhooksRequestHeaderConversionResult Convert(IHeaderDictionary headers);
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchEventSubWebhooksOptions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchEventSubWebhooksOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using TwitchySharp.Shared.EventSub.Enums;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+public class TwitchEventSubWebhooksOptions
+{
+    public JsonSerializerOptions? JsonSerializerOptions { get; set; }
+    public IReadOnlyDictionary<EventSubSubscriptionType, Type>? NotificationTypes { get; set; }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchEventSubWebhooksVerificationOptions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchEventSubWebhooksVerificationOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+public class TwitchEventSubWebhooksVerificationOptions
+{
+    public string Secret { get; set; } = string.Empty;
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksConfigurationValidator.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksConfigurationValidator.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchySharp.EventSub.Webhooks.MessageVerifiers;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+internal class TwitchWebhooksConfigurationValidator(IServiceProvider serviceProvider, ILogger<TwitchWebhooksConfigurationValidator>? logger = null) : IHostedService
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        if (_serviceProvider.GetService<ITwitchWebhookMessageVerifier>() is null)
+            logger?.LogWarning("Security Warning: Twitch webhook requests will not be validated with secrets. Please use the AddTwitchEventSubWebhooksVerification IServiceCollection extension method, register an {VerifierType} in the service provider for improved security, or disable this warning by registering a stub verifier.", nameof(ITwitchWebhookMessageVerifier));
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRequestHeaderConversionResult.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRequestHeaderConversionResult.cs
@@ -1,0 +1,7 @@
+﻿namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+internal record TwitchWebhooksRequestHeaderConversionResult
+{
+    public required EventSubWebhookRequestHeader ConvertedHeader { get; init; }
+    public IEnumerable<string> MissingHeaders { get; init; } = [];
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
@@ -33,6 +33,7 @@ public static class TwitchWebhooksRouteExtensions
             if (context.RequestServices.GetService<ITwitchWebhookMessageVerifier>() is ITwitchWebhookMessageVerifier verifier)
                 if (!await verifier.IsValid(headerConversionResult.ConvertedHeader, context.Request.Body, ct))
                     return Results.Unauthorized();
+            context.Request.Body.Position = 0;
 
             // Process
             IEventSubWebhookMessageProcessor processor = context.RequestServices.GetRequiredService<IEventSubWebhookMessageProcessor>();

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
@@ -20,6 +20,9 @@ public static class TwitchWebhooksRouteExtensions
     {
         return endpoints.MapPost(pattern, async (HttpContext context, ILoggerFactory? loggerFactory = null, CancellationToken ct = default) =>
         {
+            context.Request.EnableBuffering();
+            context.Request.Body.Position = 0;
+
             // Header Conversion
             ITwitchWebhooksHeaderConverter headerConverter = context.RequestServices.GetRequiredService<ITwitchWebhooksHeaderConverter>();
             var headerConversionResult = headerConverter.Convert(context.Request.Headers);

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
@@ -11,40 +11,81 @@ using System.Threading.Tasks;
 using TwitchySharp.EventSub.Webhooks.MessageVerifiers;
 using TwitchySharp.EventSub.Webhooks.Responses;
 using TwitchySharp.EventSub.Webhooks.WebhookMessageProcessors;
+using TwitchySharp.Shared;
 
 namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
 
 public static class TwitchWebhooksRouteExtensions
 {
+    const string LOGGER_CATEGORY = LoggingConfig.LOGGER_CATEGORY + ".MapTwitchWebhooks";
     public static IEndpointConventionBuilder MapTwitchWebhooks(this IEndpointRouteBuilder endpoints, string pattern)
-    {
-        return endpoints.MapPost(pattern, async (HttpContext context, ILoggerFactory? loggerFactory = null, CancellationToken ct = default) =>
-        {
-            context.Request.EnableBuffering();
-            context.Request.Body.Position = 0;
-
-            // Header Conversion
-            ITwitchWebhooksHeaderConverter headerConverter = context.RequestServices.GetRequiredService<ITwitchWebhooksHeaderConverter>();
-            var headerConversionResult = headerConverter.Convert(context.Request.Headers);
-            if (headerConversionResult.MissingHeaders.Any())
-                return Results.BadRequest($"Missing required headers: {string.Join(", ", headerConversionResult.MissingHeaders)}");
-
-            // Validation
-            if (context.RequestServices.GetService<ITwitchWebhookMessageVerifier>() is ITwitchWebhookMessageVerifier verifier)
-                if (!await verifier.IsValid(headerConversionResult.ConvertedHeader, context.Request.Body, ct))
-                    return Results.Unauthorized();
-            context.Request.Body.Position = 0;
-
-            // Process
-            IEventSubWebhookMessageProcessor processor = context.RequestServices.GetRequiredService<IEventSubWebhookMessageProcessor>();
-            var responseData = await processor.HandleRequest(headerConversionResult.ConvertedHeader, context.Request.Body, ct);
-
-            // Respond
-            return responseData switch
+        => endpoints.MapPost(pattern, async (HttpContext context, ILoggerFactory? loggerFactory = null, CancellationToken ct = default) =>
             {
-                CallbackVerificationResponseData { StatusCode: 200 } callbackVerificationResponse => Results.Content(callbackVerificationResponse.Challenge, "text/plain", Encoding.UTF8, callbackVerificationResponse.StatusCode),
-                _ => Results.StatusCode(responseData.StatusCode)
-            };
-        });
-    }
+                ILogger? logger = loggerFactory?.CreateLogger(LOGGER_CATEGORY);
+
+                context.Request.EnableBuffering();
+                context.Request.Body.Position = 0;
+
+                // Header Conversion
+                ITwitchWebhooksHeaderConverter headerConverter = context.RequestServices.GetRequiredService<ITwitchWebhooksHeaderConverter>();
+                var headerConversionResult = headerConverter.Convert(context.Request.Headers);
+                logger?.LogTrace("Converted headers: {HeaderConversionResult}", headerConversionResult);
+                if (headerConversionResult.MissingHeaders.Any())
+                {
+                    string missingHeadersList = string.Join(", ", headerConversionResult.MissingHeaders);
+                    logger?.LogDebug("Missing required headers: {MissingHeaders}", missingHeadersList);
+                    return Results.BadRequest($"Missing required headers: {missingHeadersList}");
+                }
+
+                using IDisposable? loggingScope = logger?.BeginScope(new Dictionary<string, object?>
+                {
+                    ["WebhookHeaders"] = headerConversionResult.ConvertedHeader,
+                    ["X-Forwarded-For"] = context.Request.Headers["X-Forwarded-For"].FirstOrDefault()
+                });
+                logger?.LogTrace("Received webhook request.");
+
+                // Validation
+                try
+                {
+                    if (context.RequestServices.GetService<ITwitchWebhookMessageVerifier>() is ITwitchWebhookMessageVerifier verifier)
+                    {
+                        if (!await verifier.IsValid(headerConversionResult.ConvertedHeader, context.Request.Body, ct))
+                        {
+                            logger?.LogWarning("Verification failed for webhook message.");
+                            return Results.Unauthorized();
+                        }
+                        logger?.LogTrace("Verification success for webhook message.");
+                    }                    
+                } 
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "An error occurred during message verification.");
+                    return Results.StatusCode(500);
+                } 
+                finally
+                {
+                    context.Request.Body.Position = 0;
+                }
+
+                // Process
+                WebhookResponseData responseData = default!;
+                try
+                {
+                    IEventSubWebhookMessageProcessor processor = context.RequestServices.GetRequiredService<IEventSubWebhookMessageProcessor>();
+                    responseData = await processor.HandleRequest(headerConversionResult.ConvertedHeader, context.Request.Body, ct);
+                    logger?.LogTrace("Processed webhook message.");
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogError(ex, "An error occurred during message processing.");
+                    return Results.StatusCode(500);
+                }
+
+                // Respond
+                return responseData switch
+                {
+                    CallbackVerificationResponseData { StatusCode: 200 } callbackVerificationResponse => Results.Content(callbackVerificationResponse.Challenge, "text/plain", Encoding.UTF8, callbackVerificationResponse.StatusCode),
+                    _ => Results.StatusCode(responseData.StatusCode)
+                };
+            });
 }

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksRouteExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchySharp.EventSub.Webhooks.MessageVerifiers;
+using TwitchySharp.EventSub.Webhooks.Responses;
+using TwitchySharp.EventSub.Webhooks.WebhookMessageProcessors;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+public static class TwitchWebhooksRouteExtensions
+{
+    public static IEndpointConventionBuilder MapTwitchWebhooks(this IEndpointRouteBuilder endpoints, string pattern)
+    {
+        return endpoints.MapPost(pattern, async (HttpContext context, ILoggerFactory? loggerFactory = null, CancellationToken ct = default) =>
+        {
+            // Header Conversion
+            ITwitchWebhooksHeaderConverter headerConverter = context.RequestServices.GetRequiredService<ITwitchWebhooksHeaderConverter>();
+            var headerConversionResult = headerConverter.Convert(context.Request.Headers);
+            if (headerConversionResult.MissingHeaders.Any())
+                return Results.BadRequest($"Missing required headers: {string.Join(", ", headerConversionResult.MissingHeaders)}");
+
+            // Validation
+            if (context.RequestServices.GetService<ITwitchWebhookMessageVerifier>() is ITwitchWebhookMessageVerifier verifier)
+                if (!await verifier.IsValid(headerConversionResult.ConvertedHeader, context.Request.Body, ct))
+                    return Results.Unauthorized();
+
+            // Process
+            IEventSubWebhookMessageProcessor processor = context.RequestServices.GetRequiredService<IEventSubWebhookMessageProcessor>();
+            var responseData = await processor.HandleRequest(headerConversionResult.ConvertedHeader, context.Request.Body, ct);
+
+            // Respond
+            return responseData switch
+            {
+                CallbackVerificationResponseData { StatusCode: 200 } callbackVerificationResponse => Results.Content(callbackVerificationResponse.Challenge, "text/plain", Encoding.UTF8, callbackVerificationResponse.StatusCode),
+                _ => Results.StatusCode(responseData.StatusCode)
+            };
+        });
+    }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
@@ -24,6 +24,7 @@ public static class TwitchEventSubWebhooksServiceExtensions
     {
         services.Configure(configureOptions);
 
+        services.TryAddScoped<ITwitchWebhooksHeaderConverter, DefaultTwitchWebhooksHeaderConverter>();
         services.TryAddScoped<ITwitchEventSubWebhookSecretsResolver>(sp =>
             new FixedSecretTwitchWebhookSecretsResolver(sp.GetRequiredService<IOptions<TwitchEventSubWebhooksVerificationOptions>>().Value.Secret ?? throw new NotSupportedException($"The {nameof(TwitchEventSubWebhooksVerificationOptions.Secret)} must be configured in the {nameof(TwitchEventSubWebhooksVerificationOptions)}."))
             );
@@ -41,6 +42,7 @@ public static class TwitchEventSubWebhooksServiceExtensions
     {
         services.Configure(configureOptions);
 
+        services.TryAddScoped<ITwitchWebhooksHeaderConverter, DefaultTwitchWebhooksHeaderConverter>();
         services.TryAddScoped<IWebhookCallbackVerifier, DefaultWebhookCallbackVerifier>();
         services.TryAddScoped<INotificationConverter>(sp => 
             new NotificationConverter(sp.GetService<IOptions<TwitchEventSubWebhooksOptions>>()?.Value.NotificationTypes)

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
@@ -37,10 +37,11 @@ public static class TwitchEventSubWebhooksServiceExtensions
 
     public static IServiceCollection AddTwitchEventSubWebhooks(
         this IServiceCollection services, 
-        Action<TwitchEventSubWebhooksOptions> configureOptions
+        Action<TwitchEventSubWebhooksOptions>? configureOptions = null
         )
     {
-        services.Configure(configureOptions);
+        if (configureOptions is not null)
+            services.Configure(configureOptions);
 
         services.TryAddScoped<ITwitchWebhooksHeaderConverter, DefaultTwitchWebhooksHeaderConverter>();
         services.TryAddScoped<IWebhookCallbackVerifier, DefaultWebhookCallbackVerifier>();

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TwitchySharp.EventSub.NotificationConverters;
+using TwitchySharp.EventSub.Webhooks.CallbackVerifiers;
+using TwitchySharp.EventSub.Webhooks.MessageVerifiers;
+using TwitchySharp.EventSub.Webhooks.SecretResolvers;
+using TwitchySharp.EventSub.Webhooks.SignatureComputers;
+using TwitchySharp.EventSub.Webhooks.WebhookMessageProcessors;
+
+namespace TwitchySharp.EventSub.Webhooks.AspNetCore;
+
+public static class TwitchEventSubWebhooksServiceExtensions
+{
+    public static IServiceCollection AddTwitchEventSubWebhooksVerification(
+        this IServiceCollection services, 
+        Action<TwitchEventSubWebhooksVerificationOptions> configureOptions
+        )
+    {
+        services.Configure(configureOptions);
+
+        services.TryAddScoped<ITwitchEventSubWebhookSecretsResolver>(sp =>
+            new FixedSecretTwitchWebhookSecretsResolver(sp.GetRequiredService<IOptions<TwitchEventSubWebhooksVerificationOptions>>().Value.Secret ?? throw new NotSupportedException($"The {nameof(TwitchEventSubWebhooksVerificationOptions.Secret)} must be configured in the {nameof(TwitchEventSubWebhooksVerificationOptions)}."))
+            );
+        services.TryAddScoped<IComputeTwitchWebhookSignature, DefaultTwitchWebhookCrypto>();
+        services.TryAddScoped<ITwitchWebhookMessageVerifier>(sp => 
+            new DefaultTwitchWebhookMessageVerifier(sp.GetRequiredService<ITwitchEventSubWebhookSecretsResolver>())
+            );
+        return services;
+    }
+
+    public static IServiceCollection AddTwitchEventSubWebhooks(
+        this IServiceCollection services, 
+        Action<TwitchEventSubWebhooksOptions> configureOptions
+        )
+    {
+        services.Configure(configureOptions);
+
+        services.TryAddScoped<IWebhookCallbackVerifier, DefaultWebhookCallbackVerifier>();
+        services.TryAddScoped<INotificationConverter>(sp => 
+            new NotificationConverter(sp.GetService<IOptions<TwitchEventSubWebhooksOptions>>()?.Value.NotificationTypes)
+            );
+        services.TryAddScoped<IEventSubWebhookMessageProcessor>(sp => 
+            new DefaultEventSubWebhookMessageProcessor(
+                sp.GetRequiredService<IWebhookEventSubHandler>(), // You must register an IWebhookEventSubHandler implementation separately
+                sp.GetService<INotificationConverter>(),
+                sp.GetService<IWebhookCallbackVerifier>(),
+                sp.GetService<IOptions<TwitchEventSubWebhooksOptions>>()?.Value.JsonSerializerOptions
+                )
+            );
+
+        return services;
+    }
+}

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchWebhooksServiceExtensions.cs
@@ -57,6 +57,8 @@ public static class TwitchEventSubWebhooksServiceExtensions
                 )
             );
 
+        services.AddHostedService<TwitchWebhooksConfigurationValidator>();
+
         return services;
     }
 }

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchySharp.EventSub.Webhooks.AspNetCore.csproj
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchySharp.EventSub.Webhooks.AspNetCore.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TwitchySharp.EventSub.Webhooks\TwitchySharp.EventSub.Webhooks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchySharp.EventSub.Webhooks.AspNetCore.csproj
+++ b/TwitchySharp.EventSub.Webhooks.AspNetCore/TwitchySharp.EventSub.Webhooks.AspNetCore.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+	<FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />

--- a/TwitchySharp.EventSub.Webhooks/MessageVerifiers/DefaultTwitchWebhookMessageVerifier.cs
+++ b/TwitchySharp.EventSub.Webhooks/MessageVerifiers/DefaultTwitchWebhookMessageVerifier.cs
@@ -38,11 +38,13 @@ public class DefaultTwitchWebhookMessageVerifier(
 
     public async ValueTask<bool> IsValid(EventSubWebhookRequestHeader requestHeaders, Stream body, CancellationToken ct = default)
     {
+        byte[] secretBytes = Encoding.UTF8.GetBytes(await _secrets.GetSecret(requestHeaders, body, ct));
+        body.Position = 0; // In case the secret resolver read the stream
         byte[] computedHash = await _signatureComputer.ComputeSignature(
-                Encoding.UTF8.GetBytes(await _secrets.GetSecret(requestHeaders, body.Reset(), ct)),
+                secretBytes,
                 requestHeaders.TwitchEventsubMessageId,
                 requestHeaders.TwitchEventsubMessageTimestamp,
-                body.Reset(),
+                body,
                 ct
                 );
         byte[] expectedHash = Encoding.UTF8.GetBytes(requestHeaders.TwitchEventsubMessageSignature);

--- a/TwitchySharp.EventSub.Webhooks/WebhookMessageProcessors/DefaultEventSubWebhookMessageProcessor.cs
+++ b/TwitchySharp.EventSub.Webhooks/WebhookMessageProcessors/DefaultEventSubWebhookMessageProcessor.cs
@@ -32,17 +32,17 @@ public class DefaultEventSubWebhookMessageProcessor(
     public async ValueTask<WebhookResponseData> HandleRequest(EventSubWebhookRequestHeader requestHeader, Stream bodyStream, CancellationToken ct = default)
         => requestHeader.TwitchEventsubMessageType switch
         {
-            TwitchEventSubMessageTypes.NOTIFICATION => await JsonSerializer.DeserializeAsync<JsonElement>(bodyStream.Reset(), _serializerOptions, ct).ConfigureAwait(false) switch
+            TwitchEventSubMessageTypes.NOTIFICATION => await JsonSerializer.DeserializeAsync<JsonElement>(bodyStream, _serializerOptions, ct).ConfigureAwait(false) switch
             {
                 { ValueKind: JsonValueKind.Undefined or JsonValueKind.Null } => throw new NotSupportedException("Notification request body cannot be null or undefined literal."),
                 { } json => await Notification(_converter.Deserialize(json), ct)
             }, 
-            TwitchEventSubMessageTypes.WEBHOOK_CALLBACK_VERIFICATION => await JsonSerializer.DeserializeAsync<CallbackVerificationRequestData>(bodyStream.Reset(), _serializerOptions, ct).ConfigureAwait(false) switch
+            TwitchEventSubMessageTypes.WEBHOOK_CALLBACK_VERIFICATION => await JsonSerializer.DeserializeAsync<CallbackVerificationRequestData>(bodyStream, _serializerOptions, ct).ConfigureAwait(false) switch
             {
                 { } data => await CallbackVerification(data.Subscription, data.Challenge, ct),
                 _ => throw new NotSupportedException("Callback verification request body cannot be null or undefined literal.")
             },
-            TwitchEventSubMessageTypes.REVOCATION => await JsonSerializer.DeserializeAsync<RevocationRequestData>(bodyStream.Reset(), _serializerOptions, ct).ConfigureAwait(false) switch
+            TwitchEventSubMessageTypes.REVOCATION => await JsonSerializer.DeserializeAsync<RevocationRequestData>(bodyStream, _serializerOptions, ct).ConfigureAwait(false) switch
             {
                 { } data => await Revocation(data.Subscription, ct),
                 _ => throw new NotSupportedException("Revocation request body cannot be null or undefined literal.")

--- a/TwitchySharp.Shared/LoggingConfig.cs
+++ b/TwitchySharp.Shared/LoggingConfig.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitchySharp.Shared;
+
+public static class LoggingConfig
+{
+    public const string LOGGER_CATEGORY = "TwitchySharp";
+}

--- a/TwitchySharp.sln
+++ b/TwitchySharp.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webho
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webhooks.AspNetCore", "TwitchySharp.EventSub.Webhooks.AspNetCore\TwitchySharp.EventSub.Webhooks.AspNetCore.csproj", "{4698B3CC-61B4-07AD-9A8D-5727312C9680}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration", "TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration\TwitchySharp.EventSub.Webhooks.AspNetCore.Tests.Integration.csproj", "{4FE1C282-A74F-479E-B791-C0B7C0CB3AA9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,10 @@ Global
 		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FE1C282-A74F-479E-B791-C0B7C0CB3AA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FE1C282-A74F-479E-B791-C0B7C0CB3AA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FE1C282-A74F-479E-B791-C0B7C0CB3AA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FE1C282-A74F-479E-B791-C0B7C0CB3AA9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TwitchySharp.sln
+++ b/TwitchySharp.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.1.11312.151 d18.0
+VisualStudioVersion = 18.1.11312.151
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TwitchySharp.Api", "TwitchySharp.Api\TwitchySharp.Api.csproj", "{93D6F7C2-FF51-4B9C-9307-3F0C99A8EB7B}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webhooks", "TwitchySharp.EventSub.Webhooks\TwitchySharp.EventSub.Webhooks.csproj", "{2856906B-D8C1-4ECB-8BB1-0C879BD4368B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webhooks.Tests.Unit", "TwitchySharp.EventSub.Webhooks.Tests.Unit\TwitchySharp.EventSub.Webhooks.Tests.Unit.csproj", "{B86F5725-99C4-40E2-A131-DE7DF1442F6C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitchySharp.EventSub.Webhooks.AspNetCore", "TwitchySharp.EventSub.Webhooks.AspNetCore\TwitchySharp.EventSub.Webhooks.AspNetCore.csproj", "{4698B3CC-61B4-07AD-9A8D-5727312C9680}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{B86F5725-99C4-40E2-A131-DE7DF1442F6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B86F5725-99C4-40E2-A131-DE7DF1442F6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B86F5725-99C4-40E2-A131-DE7DF1442F6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4698B3CC-61B4-07AD-9A8D-5727312C9680}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We add a project dedicated to webhook usage with ASP.NET Core projects. This makes it easy to create a Twitch webhook server that can validate and accept webhook requests from Twitch.

All integration tests passing.