### PR TITLE
Refactor authorization endpoints to property-based pattern

### DIFF
--- a/TwitchySharp.Api/Authorization/Endpoints/AuthorizationCode/AuthorizationCodeRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/AuthorizationCode/AuthorizationCodeRequest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using TwitchySharp.Api.Authorization.ClientUrls;
@@ -17,25 +17,33 @@ namespace TwitchySharp.Api.Authorization;
 public record AuthorizationCodeRequest
     : TwitchAuthorizationRequest<AuthorizationCodeResponse>
 {
-    /// <param name="clientId">The client id of the application.</param>
-    /// <param name="clientSecret">The client secret of the application.</param>
-    /// <param name="code">The code query parameter obtained from the redirect of an <see cref="AuthorizationCodeGrantUrl"/>.</param>
-    /// <param name="redirectUri">
+    protected override string Path => "/token";
+    public override HttpMethod Method => HttpMethod.Post;
+    public override HttpContent? Content
+        => new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            { "client_id", ClientId },
+            { "client_secret", ClientSecret },
+            { "code", Code },
+            { "grant_type", "authorization_code" },
+            { "redirect_uri", RedirectUri.ToString() }
+        });
+
+    /// <summary>
+    /// The client id of the application.
+    /// </summary>
+    public required ClientId ClientId { get; init; }
+    /// <summary>
+    /// The client secret of the application.
+    /// </summary>
+    public required ClientSecret ClientSecret { get; init; }
+    /// <summary>
+    /// The code query parameter obtained from the redirect of an <see cref="AuthorizationCodeGrantUrl"/>.
+    /// </summary>
+    public required string Code { get; init; }
+    /// <summary>
     /// The redirect URI of the application (this is registered via the Twitch developer console).
     /// This should be the URI that the <see cref="AuthorizationCodeGrantUrl"/> redirected to.
-    /// </param>
-    public AuthorizationCodeRequest(ClientId clientId, ClientSecret clientSecret, string code, Uri redirectUri)
-        : base("/token")
-    {
-        Method = HttpMethod.Post;
-        ClientId = clientId;
-        Content = new FormUrlEncodedContent(new Dictionary<string, string>
-        {
-            { "client_id", clientId },
-            { "client_secret", clientSecret },
-            { "code", code },
-            { "grant_type", "authorization_code" },
-            { "redirect_uri", redirectUri.ToString() }
-        });
-    }
+    /// </summary>
+    public required Uri RedirectUri { get; init; }
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/DeviceCode/DeviceCodeRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/DeviceCode/DeviceCodeRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using TwitchySharp.Shared.Models;
 
@@ -12,17 +12,21 @@ namespace TwitchySharp.Api.Authorization;
 public record DeviceCodeRequest
     : TwitchAuthorizationRequest<DeviceCodeResponse>
 {
-    /// <param name="clientId">The client id of the application.</param>
-    /// <param name="scopes">The <see href="https://dev.twitch.tv/docs/authentication/scopes/">authorization scopes</see> to request.</param>
-    public DeviceCodeRequest(ClientId clientId, IEnumerable<Scope> scopes)
-        : base("/device")
-    {
-        Method = HttpMethod.Post;
-        ClientId = clientId;
-        Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    protected override string Path => "/device";
+    public override HttpMethod Method => HttpMethod.Post;
+    public override HttpContent? Content
+        => new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            { "client_id", clientId },
-            { "scopes", scopes.FormatScopes() }
+            { "client_id", ClientId },
+            { "scopes", Scopes.FormatScopes() }
         });
-    }
+
+    /// <summary>
+    /// The client id of the application.
+    /// </summary>
+    public required ClientId ClientId { get; init; }
+    /// <summary>
+    /// The <see href="https://dev.twitch.tv/docs/authentication/scopes/">authorization scopes</see> to request.
+    /// </summary>
+    public required IEnumerable<Scope> Scopes { get; init; }
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/DeviceCodeToken/DeviceCodeTokenRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/DeviceCodeToken/DeviceCodeTokenRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using TwitchySharp.Shared.Models;
 
@@ -9,20 +9,27 @@ namespace TwitchySharp.Api.Authorization;
 public record DeviceCodeTokenRequest
     : TwitchAuthorizationRequest<DeviceCodeTokenResponse>
 {
-    /// <param name="clientId">The client id of the application making the request.</param>
-    /// <param name="scopes">The <see href="https://dev.twitch.tv/docs/authentication/scopes/">authorization scopes</see> to request.</param>
-    /// <param name="deviceCode">The device code obtained from a <see cref="DeviceCodeRequest"/></param>
-    public DeviceCodeTokenRequest(ClientId clientId, IEnumerable<Scope> scopes, DeviceCode deviceCode)
-        : base("/token")
-    {
-        Method = HttpMethod.Post;
-        ClientId = clientId;
-        Content = new FormUrlEncodedContent(new Dictionary<string, string>
+    protected override string Path => "/token";
+    public override HttpMethod Method => HttpMethod.Post;
+    public override HttpContent? Content
+        => new FormUrlEncodedContent(new Dictionary<string, string>
         {
-            { "client_id", clientId },
-            { "scope", scopes.FormatScopes() },
-            { "device_code", deviceCode },
+            { "client_id", ClientId },
+            { "scope", Scopes.FormatScopes() },
+            { "device_code", DeviceCode },
             { "grant_type", "urn:ietf:params:oauth:grant-type:device_code" }
         });
-    }
+
+    /// <summary>
+    /// The client id of the application making the request.
+    /// </summary>
+    public required ClientId ClientId { get; init; }
+    /// <summary>
+    /// The <see href="https://dev.twitch.tv/docs/authentication/scopes/">authorization scopes</see> to request.
+    /// </summary>
+    public required IEnumerable<Scope> Scopes { get; init; }
+    /// <summary>
+    /// The device code obtained from a <see cref="DeviceCodeRequest"/>.
+    /// </summary>
+    public required DeviceCode DeviceCode { get; init; }
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/OidcJwk/OidcJwkRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/OidcJwk/OidcJwkRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Net.Http;
+using System.Net.Http;
 
 namespace TwitchySharp.Api.Authorization;
 /// <summary>
@@ -10,9 +10,6 @@ namespace TwitchySharp.Api.Authorization;
 public record OidcJwkRequest
     : TwitchAuthorizationRequest<OidcJwkResponse>
 {
-    public OidcJwkRequest()
-        : base("/keys")
-    {
-        Method = HttpMethod.Get;
-    }
+    protected override string Path => "/keys";
+    public override HttpMethod Method => HttpMethod.Get;
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/RevokeAccessToken/RevokeAccessTokenRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/RevokeAccessToken/RevokeAccessTokenRequest.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using TwitchySharp.Shared.Models;
 
@@ -12,18 +12,21 @@ namespace TwitchySharp.Api.Authorization;
 public record RevokeAccessTokenRequest
     : TwitchAuthorizationRequest<RevokeAccessTokenResponse>
 {
-    /// <param name="clientId">The client id of the application that the <paramref name="accessToken"/> was created under.</param>
-    /// <param name="accessToken">The access token to revoke.</param>
-    public RevokeAccessTokenRequest(ClientId clientId, AccessToken accessToken)
-        : base("/revoke")
-    {
-        Method = HttpMethod.Post;
-        ClientId = clientId;
-        AccessToken = accessToken;
-        Content = new FormUrlEncodedContent(new Dictionary<string, string>()
+    protected override string Path => "/revoke";
+    public override HttpMethod Method => HttpMethod.Post;
+    public override HttpContent? Content
+        => new FormUrlEncodedContent(new Dictionary<string, string>()
         {
-            { "client_id", clientId },
-            { "token", accessToken }
+            { "client_id", ClientId },
+            { "token", AccessToken }
         });
-    }
+
+    /// <summary>
+    /// The client id of the application that the <see cref="AccessToken"/> was created under.
+    /// </summary>
+    public required ClientId ClientId { get; init; }
+    /// <summary>
+    /// The access token to revoke.
+    /// </summary>
+    public required AccessToken AccessToken { get; init; }
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/RevokeAccessToken/RevokeAccessTokenRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/RevokeAccessToken/RevokeAccessTokenRequest.cs
@@ -4,7 +4,7 @@ using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Authorization;
 /// <summary>
-/// Revokes a valid user access token so that it is no longer valid.
+/// Revokes a valid app or user access token so that it is no longer valid.
 /// </summary>
 /// <remarks>
 /// See <see href="https://dev.twitch.tv/docs/authentication/revoke-tokens/">Revoke Tokens</see> for more information.

--- a/TwitchySharp.Api/Authorization/Endpoints/UserInfo/UserInfoRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/UserInfo/UserInfoRequest.cs
@@ -1,8 +1,9 @@
-﻿using System.Net.Http;
+using System.Collections.Generic;
+using System.Net.Http;
 
 namespace TwitchySharp.Api.Authorization;
 /// <summary>
-/// Gets a set of OIDC claims associated with the user access token used to make the request
+/// Gets a set of OIDC claims associated with the user access token used to make the request.
 /// </summary>
 /// <remarks>
 /// Requires a user access token including <see cref="Scope.OpenId"/>.
@@ -10,16 +11,31 @@ namespace TwitchySharp.Api.Authorization;
 /// See <see href="https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#getting-claims-information-from-an-access-token">getting claims information from an access token</see> for more information.
 /// </remarks>
 public record UserInfoRequest
-    : TwitchAuthorizationRequest<TwitchOidc>
+    : TwitchAuthorizationRequest<TwitchOidc>, IRequireAuthorization
 {
-    /// <param name="accessToken">
+    protected override string Path => "/userinfo";
+    public override HttpMethod Method => HttpMethod.Get;
+
+    /// <summary>
     /// The user access token of the user to get claims information for.
+    /// </summary>
+    /// <remarks>
     /// Requires <see cref="Scope.OpenId"/>.
-    /// </param>
-    public UserInfoRequest(UserAccessToken accessToken)
-        : base("/userinfo")
-    {
-        Method = HttpMethod.Get;
-        AccessToken = accessToken;
-    }
+    /// </remarks>
+    public required UserAccessToken AccessToken { get; init; }
+
+    /// <summary>
+    /// The identity for this request. UserInfo does not require a specific identity context.
+    /// </summary>
+    public TwitchApiIdentity Identity { get; init; } = TwitchApiIdentity.None;
+
+    /// <summary>
+    /// Requires <see cref="Scope.OpenId"/>.
+    /// </summary>
+    public IEnumerable<Scope> ValidScopes => [ Scope.OpenId ];
+
+    /// <summary>
+    /// The access token used for authorization. Returns the <see cref="AccessToken"/> property.
+    /// </summary>
+    public AccessToken? OverrideAccessToken => AccessToken;
 }

--- a/TwitchySharp.Api/Authorization/Endpoints/UserInfo/UserInfoRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/UserInfo/UserInfoRequest.cs
@@ -25,8 +25,12 @@ public record UserInfoRequest
     public required UserAccessToken AccessToken { get; init; }
 
     /// <summary>
-    /// The identity for this request. UserInfo does not require a specific identity context.
+    /// The identity for this request.
     /// </summary>
+    /// <remarks>
+    /// UserInfo does not require a specific identity context.
+    /// The <see cref="AccessToken"/> will be used in the Authorization header.
+    /// </remarks>
     public TwitchApiIdentity Identity { get; init; } = TwitchApiIdentity.None;
 
     /// <summary>

--- a/TwitchySharp.Api/Authorization/Endpoints/ValidateAccessToken/ValidateAccessTokenRequest.cs
+++ b/TwitchySharp.Api/Authorization/Endpoints/ValidateAccessToken/ValidateAccessTokenRequest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 
 namespace TwitchySharp.Api.Authorization;
@@ -26,14 +25,18 @@ public record ValidateAccessTokenRequest
     public required UserAccessToken AccessToken { get; init; }
 
     /// <summary>
-    /// The identity for this request. Validation does not require a specific identity context.
+    /// The identity for this request.
     /// </summary>
+    /// <remarks>
+    /// Validation does not require a specific identity context.
+    /// The <see cref="AccessToken"/> will be used in the Authorization header.
+    /// </remarks>
     public TwitchApiIdentity Identity { get; init; } = TwitchApiIdentity.None;
 
     /// <summary>
     /// No specific scopes are required for token validation.
     /// </summary>
-    public IEnumerable<Scope> ValidScopes => Enumerable.Empty<Scope>();
+    public IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The access token used for authorization. Returns the <see cref="AccessToken"/> to validate.


### PR DESCRIPTION
## Summary

Refactors all remaining authorization endpoint request classes from constructor-based to property-based pattern.

Addresses part of #14 - Authorization Endpoints section.

## Changes

### Refactored Requests (6)

| Request | Pattern | Notes |
|---------|---------|-------|
| `OidcJwkRequest` | Simple GET | No parameters, just Path and Method |
| `AuthorizationCodeRequest` | POST with form data | ClientId, ClientSecret, Code, RedirectUri |
| `DeviceCodeRequest` | POST with form data | ClientId, Scopes |
| `DeviceCodeTokenRequest` | POST with form data | ClientId, Scopes, DeviceCode |
| `RevokeAccessTokenRequest` | POST with form data | ClientId, AccessToken |
| `UserInfoRequest` | GET with Bearer auth | Implements `IRequireAuthorization` |

### Already Refactored (3)
- `AccessTokenRefreshRequest` ✅
- `ClientCredentialsRequest` ✅
- `ValidateAccessTokenRequest` ✅

## Pattern Applied

**Before (constructor-based):**
```csharp
public record SomeRequest : TwitchAuthorizationRequest<SomeResponse>
{
    public SomeRequest(ClientId clientId, string code)
        : base("/token")
    {
        Method = HttpMethod.Post;
        Content = new FormUrlEncodedContent(...);
    }
}
```

**After (property-based):**
```csharp
public record SomeRequest : TwitchAuthorizationRequest<SomeResponse>
{
    protected override string Path => "/token";
    public override HttpMethod Method => HttpMethod.Post;
    public override HttpContent? Content => new FormUrlEncodedContent(...);

    public required ClientId ClientId { get; init; }
    public required string Code { get; init; }
}
```

## Special Case: UserInfoRequest

This request requires Bearer authorization, so it implements `IRequireAuthorization`:
- `Identity = TwitchApiIdentity.None` (no Client-Id header needed)
- `ValidScopes = [ Scope.OpenId ]`
- `OverrideAccessToken` returns the provided access token

## Test Plan

- [ ] Verify each refactored request compiles without errors
- [ ] Verify XML documentation preserved on all properties
- [ ] Verify Content property generates correct form data

🤖 Generated with [Claude Code](https://claude.com/claude-code)