### PR TITLE
EventSub API Refactor

### DIFF
--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_CreateEventSubSubscriptionRequest.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_CreateEventSubSubscriptionRequest
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+    private const string MOCK_SESSION_ID = "session_abc";
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        var userIdentity = Assert.IsType<UserIdentity>(identity);
+        Assert.Equal(new UserId(MOCK_USER_ID), userIdentity.UserId);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookUserAuthorizedType_ReturnsDefault()
+    {
+        // Arrange - Webhook transport with user authorized type should use app identity
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketAppOnlyType_ReturnsDefault()
+    {
+        // Arrange - App-only subscription type with websocket transport
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookAppOnlyType_ReturnsDefault()
+    {
+        // Arrange
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedTypeMissingCondition_ThrowsInvalidOperationException()
+    {
+        // Arrange - User authorized type missing the authorizing user condition
+        var subscriptionType = new MockUserAuthorizedTypeWithMissingCondition();
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => GetDefaultIdentity(request));
+    }
+
+    [Fact]
+    public void ValidScopes_WithUserAuthorizedType_ReturnsTypeScopes()
+    {
+        // Arrange
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var scopes = request.ValidScopes;
+
+        // Assert
+        Assert.Contains(Scope.ModeratorReadFollowers, scopes);
+    }
+
+    [Fact]
+    public void ValidScopes_WithAppOnlyType_ReturnsEmpty()
+    {
+        // Arrange
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var scopes = request.ValidScopes;
+
+        // Assert
+        Assert.Empty(scopes);
+    }
+
+    /// <summary>
+    /// Helper to access the protected DefaultIdentity property through the public interface.
+    /// </summary>
+    private static TwitchApiIdentity GetDefaultIdentity(CreateEventSubSubscriptionRequest request)
+    {
+        // The Identity property falls back to DefaultIdentity when not set
+        // We can test this by not setting Identity and checking what Identity resolves to
+        return request.Identity;
+    }
+
+    /// <summary>
+    /// A mock user-authorized subscription type that is missing the authorizing user condition.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithMissingCondition : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        // Condition is missing the moderator_user_id key
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            [new ConditionKey("broadcaster_user_id")] = new UserId(MOCK_BROADCASTER_ID)
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_DeleteEventSubSubscriptionRequest.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_DeleteEventSubSubscriptionRequest
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+    private const string MOCK_SUBSCRIPTION_ID = "sub_123";
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedSubscription_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow with websocket transport
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID,
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        var userIdentity = Assert.IsType<UserIdentity>(identity);
+        Assert.Equal(new UserId(MOCK_USER_ID), userIdentity.UserId);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookSubscription_ReturnsDefault()
+    {
+        // Arrange - Webhook transport should use app identity
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID,
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithConduitSubscription_ReturnsDefault()
+    {
+        // Arrange - Conduit transport should use app identity
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+            },
+            EventSubTransportMethod.Conduit
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithSubscriptionIdOnly_ReturnsDefault()
+    {
+        // Arrange - No subscription provided, only ID
+        var request = new DeleteEventSubSubscriptionRequest
+        {
+            SubscriptionId = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID)
+        };
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedMissingCondition_ThrowsInvalidOperationException()
+    {
+        // Arrange - User authorized type with websocket but missing the authorizing user condition
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+                // moderator_user_id is missing
+            },
+            EventSubTransportMethod.Websocket
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => request.Identity);
+    }
+
+    [Fact]
+    public void Constructor_WithSubscription_SetsSubscriptionId()
+    {
+        // Arrange
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Assert
+        Assert.Equal(subscription.Id, request.SubscriptionId);
+    }
+
+    private static EventSubSubscription CreateSubscription(
+        EventSubSubscriptionType type,
+        Dictionary<string, string> condition,
+        EventSubTransportMethod transportMethod)
+    {
+        return new EventSubSubscription
+        {
+            Id = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID),
+            Status = EventSubSubscriptionStatus.Enabled,
+            Type = new EventSubSubscriptionTypeName(type.Type),
+            Version = new EventSubSubscriptionTypeVersion(type.Version),
+            Condition = condition.ToImmutableDictionary(
+                kvp => new ConditionKey(kvp.Key),
+                kvp => kvp.Value),
+            CreatedAt = DateTimeOffset.UtcNow,
+            Transport = new EventSubSubscriptionTransport
+            {
+                Method = transportMethod
+            },
+            Cost = 1
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_EventSubIdentityResolver.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_EventSubIdentityResolver.cs
@@ -1,0 +1,162 @@
+using System.Collections.Immutable;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_EventSubIdentityResolver
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_SUBSCRIPTION_ID = "sub_123";
+
+    [Fact]
+    public void GetAuthorizingUser_WithUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow uses moderator_user_id as the authorizing user key
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999",
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithAppOnlyType_ReturnsNull()
+    {
+        // Arrange - StreamOnline does not require user authorization
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithMissingConditionKey_ReturnsNull()
+    {
+        // Arrange - ChannelFollow requires moderator_user_id but it's missing
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999"
+                // moderator_user_id is missing
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithWebhookTransportUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange - Even with webhook transport, the authorizing user should be resolved
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999",
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithBroadcasterAuthorizedType_ReturnsCorrectUser()
+    {
+        // Arrange - ChannelSubscribe uses broadcaster_user_id as the authorizing user key
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelSubscribe,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithUnknownSubscriptionType_ReturnsNull()
+    {
+        // Arrange - Unknown/custom subscription type not in the dictionary
+        var subscription = CreateSubscription(
+            new EventSubSubscriptionType("unknown.type", "1"),
+            new Dictionary<string, string>
+            {
+                ["user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private static EventSubSubscription CreateSubscription(
+        EventSubSubscriptionType type,
+        Dictionary<string, string> condition,
+        EventSubTransportMethod transportMethod)
+    {
+        return new EventSubSubscription
+        {
+            Id = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID),
+            Status = EventSubSubscriptionStatus.Enabled,
+            Type = new EventSubSubscriptionTypeName(type.Type),
+            Version = new EventSubSubscriptionTypeVersion(type.Version),
+            Condition = condition.ToImmutableDictionary(
+                kvp => new ConditionKey(kvp.Key),
+                kvp => kvp.Value),
+            CreatedAt = DateTimeOffset.UtcNow,
+            Transport = new EventSubSubscriptionTransport
+            {
+                Method = transportMethod
+            },
+            Cost = 1
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_UserAuthorizedSubscriptionTypeExtensions.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_UserAuthorizedSubscriptionTypeExtensions.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_UserAuthorizedSubscriptionTypeExtensions
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+
+    [Fact]
+    public void GetAuthorizingUser_WithValidCondition_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow has moderator_user_id as the authorizing user
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithMissingConditionKey_ReturnsNull()
+    {
+        // Arrange - A mock type that claims to have a condition key that doesn't exist
+        var subscriptionType = new MockUserAuthorizedTypeWithMissingKey();
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithNonUserIdConditionValue_ReturnsNull()
+    {
+        // Arrange - A mock type where the condition value is not a UserId
+        var subscriptionType = new MockUserAuthorizedTypeWithWrongValueType();
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithBroadcasterAuthorizedType_ReturnsCorrectUser()
+    {
+        // Arrange - ChannelSubscribe uses broadcaster_user_id as the authorizing user
+        var subscriptionType = new ChannelSubscribe(new UserId(MOCK_USER_ID));
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    /// <summary>
+    /// Mock type where the authorizing user condition key doesn't exist in the condition.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithMissingKey : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("nonexistent_key");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            [new ConditionKey("broadcaster_user_id")] = new UserId(MOCK_BROADCASTER_ID)
+        };
+    }
+
+    /// <summary>
+    /// Mock type where the condition value is not a UserId.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithWrongValueType : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            // Value is a string, not a UserId
+            [new ConditionKey("user_id")] = "not_a_user_id_type"
+        };
+    }
+}

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 using TwitchySharp.Api.Authorization;
@@ -57,7 +58,7 @@ internal record CreateEventSubSubscriptionRequestData
         {
             Type = subscription.Type.Type.Type,
             Version = subscription.Type.Type.Version,
-            Condition = subscription.Type.Condition,
+            Condition = subscription.Type.Condition.ToDictionary(kvp => (string)kvp.Key, kvp => kvp.Value),
             Transport = subscription.Transport
         };
 }

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 using TwitchySharp.Api.Authorization;
+using TwitchySharp.Shared.EventSub;
 using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub;
@@ -19,6 +22,10 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// If the subscription type requires a user access token authorization, the user must have created a user access token with the required <see cref="Scope"/> for this application (i.e., for this application's client id).
 /// It is not required to send this user access token in the request.
 /// </para>
+/// <para>
+/// The identity and scopes for the request are automatically determined based on the <see cref="Subscription"/> transport and type.
+/// You do not need to manually configure them unless you need to override the default behavior.
+/// </para>
 /// See <see href="https://dev.twitch.tv/docs/api/reference/#create-eventsub-subscription">Create EventSub Subscription</see> for more information.
 /// </remarks>
 public record CreateEventSubSubscriptionRequest
@@ -26,14 +33,34 @@ public record CreateEventSubSubscriptionRequest
 {
     protected override string Path => "/eventsub/subscriptions";
     public override HttpMethod Method => HttpMethod.Post;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
+    protected override TwitchApiIdentity DefaultIdentity => (Subscription.Transport.Method == EventSubTransportMethod.Websocket, Subscription.Type) switch
+    {
+        (true, IUserAuthorizedSubscriptionType userAuthorized) => GetAuthorizingUser(userAuthorized)
+            ?? throw new InvalidOperationException(
+                $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.Type.Type} when attempting to create the subscription. " +
+                $"Set the {nameof(Identity)} property manually to suppress this error. " +
+                $"The condition for this subscription may be missing the expected key '{userAuthorized.AuthorizingUserConditionKey}'."),
+        _ => TwitchApiIdentity.Default
+    };
+    public override IEnumerable<Scope> ValidScopes => Subscription.Type switch
+    {
+        IUserAuthorizedSubscriptionType userAuthorized => userAuthorized.ValidScopes,
+        _ => []
+    };
     public override object? ContentObject => (CreateEventSubSubscriptionRequestData)Subscription;
 
     /// <summary>
     /// The subscription to create.
     /// </summary>
     public required NewEventSubSubscription Subscription { get; set; }
+
+    private UserIdentity? GetAuthorizingUser(IUserAuthorizedSubscriptionType subscriptionType)
+    {
+        var conditionKey = subscriptionType.AuthorizingUserConditionKey;
+        if (!subscriptionType.Condition.TryGetValue(conditionKey, out var userId))
+            return null;
+        return new UserIdentity(new UserId(userId?.ToString() ?? string.Empty));
+    }
 }
 
 internal record CreateEventSubSubscriptionRequestData

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -54,7 +54,7 @@ public record CreateEventSubSubscriptionRequest
     /// <summary>
     /// The subscription to create.
     /// </summary>
-    public required NewEventSubSubscription Subscription { get; set; }
+    public required EventSubSubscriptionSpecification Subscription { get; set; }
 }
 
 internal record CreateEventSubSubscriptionRequestData
@@ -66,7 +66,7 @@ internal record CreateEventSubSubscriptionRequestData
     [JsonPropertyName("condition")]
     public required IReadOnlyDictionary<string, object> Condition { get; init; }
     [JsonPropertyName("transport")]
-    public required NewEventSubSubscriptionTransport Transport { get; init; }
+    public required EventSubSubscriptionTransportSpecification Transport { get; init; }
     [JsonPropertyName("is_batching_enabled")]
     public bool? IsBatchingEnabled => Type switch // Kind of jank but this is the only type that requires this.
     {
@@ -74,7 +74,7 @@ internal record CreateEventSubSubscriptionRequestData
         _ => null
     };
 
-    public static explicit operator CreateEventSubSubscriptionRequestData(NewEventSubSubscription subscription)
+    public static explicit operator CreateEventSubSubscriptionRequestData(EventSubSubscriptionSpecification subscription)
         => new()
         {
             Type = subscription.Type.Type.Type,

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -4,9 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json.Serialization;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub;
 using TwitchySharp.Shared.EventSub.Constants;
-using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub;
@@ -33,13 +31,17 @@ public record CreateEventSubSubscriptionRequest
 {
     protected override string Path => "/eventsub/subscriptions";
     public override HttpMethod Method => HttpMethod.Post;
-    protected override TwitchApiIdentity DefaultIdentity => (Subscription.Transport.Method == EventSubTransportMethod.Websocket, Subscription.Type) switch
+    protected override TwitchApiIdentity DefaultIdentity => Subscription.RequiresUserAccessToken() switch
     {
-        (true, IUserAuthorizedSubscriptionType userAuthorized) => GetAuthorizingUser(userAuthorized)
-            ?? throw new InvalidOperationException(
-                $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.Type.Type} when attempting to create the subscription. " +
-                $"Set the {nameof(Identity)} property manually to suppress this error. " +
-                $"The condition for this subscription may be missing the expected key '{userAuthorized.AuthorizingUserConditionKey}'."),
+        true => Subscription.Type switch
+        {
+            IUserAuthorizedSubscriptionType userAuthorized => userAuthorized.GetAuthorizingUser()
+                ?? throw new InvalidOperationException(
+                    $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.Type.Type} when attempting to create the subscription. " +
+                    $"Set the {nameof(Identity)} property manually to suppress this error. " +
+                    $"The condition for this subscription may be missing the expected key '{userAuthorized.AuthorizingUserConditionKey}'."),
+            _ => TwitchApiIdentity.Default
+        },
         _ => TwitchApiIdentity.Default
     };
     public override IEnumerable<Scope> ValidScopes => Subscription.Type switch
@@ -53,14 +55,6 @@ public record CreateEventSubSubscriptionRequest
     /// The subscription to create.
     /// </summary>
     public required NewEventSubSubscription Subscription { get; set; }
-
-    private UserIdentity? GetAuthorizingUser(IUserAuthorizedSubscriptionType subscriptionType)
-    {
-        var conditionKey = subscriptionType.AuthorizingUserConditionKey;
-        if (!subscriptionType.Condition.TryGetValue(conditionKey, out var userId))
-            return null;
-        return new UserIdentity(new UserId(userId?.ToString() ?? string.Empty));
-    }
 }
 
 internal record CreateEventSubSubscriptionRequestData

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json.Serialization;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Constants;
 using TwitchySharp.Shared.Models;
@@ -36,11 +37,16 @@ public record CreateEventSubSubscriptionRequest
 
 internal record CreateEventSubSubscriptionRequestData
 {
-    public required EventSubSubscriptionTypeName Type { get; init; }
-    public required EventSubSubscriptionTypeVersion Version { get; init; }
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+    [JsonPropertyName("condition")]
     public required IReadOnlyDictionary<string, object> Condition { get; init; }
+    [JsonPropertyName("transport")]
     public required NewEventSubSubscriptionTransport Transport { get; init; }
-    public bool? IsBatchingEnabled => Type.Value switch // Kind of jank but this is the only type that requires this.
+    [JsonPropertyName("is_batching_enabled")]
+    public bool? IsBatchingEnabled => Type switch // Kind of jank but this is the only type that requires this.
     {
         EventSubSubscriptionTypeNames.DROP_ENTITLEMENT_GRANT => true,
         _ => null
@@ -49,8 +55,8 @@ internal record CreateEventSubSubscriptionRequestData
     public static explicit operator CreateEventSubSubscriptionRequestData(NewEventSubSubscription subscription)
         => new()
         {
-            Type = subscription.Type.Name,
-            Version = subscription.Type.Version,
+            Type = subscription.Type.Type.Type,
+            Version = subscription.Type.Type.Version,
             Condition = subscription.Type.Condition,
             Transport = subscription.Transport
         };

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Helpers;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub;
@@ -31,7 +33,12 @@ public record DeleteEventSubSubscriptionRequest()
     {
         not null => Subscription.RequiresUserAccessToken() switch
         {
-            true => Subscription.GetAuthorizingUser(),
+            true => Subscription.GetAuthorizingUser() ?? throw new InvalidOperationException(
+                $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.GetSubscriptionType()} when attempting to delete the subscription." + 
+                $"Set the {nameof(Identity)} property manually to suppress this error." +
+                $"The {nameof(EventSubSubscription)} instance passed to this {nameof(DeleteEventSubSubscriptionRequest)} may be malformed, " +
+                $"or the respective {nameof(EventSubSubscriptionType)} may not be supported yet. If the latter is the case, please raise an issue on GitHub with the {nameof(EventSubSubscription)} you are trying to delete."
+                ),
             _ => null
         },
         _ => null

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Helpers;
@@ -14,18 +15,61 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// <br/>
 /// Requires a user access token if you use the <see cref="WebsocketSubscriptionTransport"/> as the subscription's transport. No particular <see cref="Scope"/> is required.
 /// </para>
+/// <para>
+/// When using the <see cref="DeleteEventSubSubscriptionRequest(EventSubSubscription)"/> constructor or setting the <see cref="Subscription"/>, 
+/// the identity for the request introspected from the <see cref="Subscription"/>. It does not need to be manually configured unless you need to
+/// manually configure the <see cref="ClientIdentity"/>.
+/// </para>
 /// See <see href="https://dev.twitch.tv/docs/api/reference/#delete-eventsub-subscription">Delete EventSub Subscription</see> for more information.
 /// </remarks>
-public record DeleteEventSubSubscriptionRequest
+public record DeleteEventSubSubscriptionRequest()
     : TwitchHelixRequest<DeleteEventSubSubscriptionResponse>
 {
     protected override string Path => "/eventsub/subscriptions";
     public override HttpMethod Method => HttpMethod.Delete;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
+    protected override TwitchApiIdentity DefaultIdentity => Subscription switch
+    {
+        not null => Subscription.RequiresUserAccessToken() switch
+        {
+            true => Subscription.GetAuthorizingUser(),
+            _ => null
+        },
+        _ => null
+    } ?? TwitchApiIdentity.Default;
     public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", SubscriptionId);
+
+    /// <summary>
+    /// The subscription to delete.
+    /// </summary>
+    /// <remarks>
+    /// Auto-sets <see cref="SubscriptionId"/> to support <see langword="with"/> syntax.
+    /// For first time initialization use the constructor.
+    /// </remarks>
+    public EventSubSubscription? Subscription
+    {
+        get => field;
+        init
+        {
+            field = value;
+            if (value is not null)
+                SubscriptionId = value.Id;
+        }
+    }
+    /// <summary>
+    /// Automatically sets the required <see cref="SubscriptionId"/>.
+    /// </summary>
+    /// <remarks>
+    /// You should use this in most cases, as it will set the correct <see cref="TwitchApiIdentity"/> to use with the request.
+    /// If you only set <see cref="SubscriptionId"/>, the default identity is <see cref="TwitchApiIdentity.Default"/>.
+    /// </remarks>
+    /// <param name="subscription">The subscription to delete.</param>
+    [SetsRequiredMembers]
+    public DeleteEventSubSubscriptionRequest(EventSubSubscription subscription)
+        : this()
+        => (Subscription, SubscriptionId) = (subscription, subscription.Id);
 
     /// <summary>
     /// The id of the subscription to delete.

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
@@ -34,8 +34,8 @@ public record DeleteEventSubSubscriptionRequest()
         not null => Subscription.RequiresUserAccessToken() switch
         {
             true => Subscription.GetAuthorizingUser() ?? throw new InvalidOperationException(
-                $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.GetSubscriptionType()} when attempting to delete the subscription." + 
-                $"Set the {nameof(Identity)} property manually to suppress this error." +
+                $"Failed to resolve required {nameof(UserIdentity)} from subscription type {Subscription.GetSubscriptionType()} when attempting to delete the subscription. " + 
+                $"Set the {nameof(Identity)} property manually to suppress this error. " +
                 $"The {nameof(EventSubSubscription)} instance passed to this {nameof(DeleteEventSubSubscriptionRequest)} may be malformed, " +
                 $"or the respective {nameof(EventSubSubscriptionType)} may not be supported yet. If the latter is the case, please raise an issue on GitHub with the {nameof(EventSubSubscription)} you are trying to delete."
                 ),

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/GetEventSubSubscriptions/GetEventSubSubscriptionsRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/GetEventSubSubscriptions/GetEventSubSubscriptionsRequest.cs
@@ -10,6 +10,10 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// Gets a list of EventSub subscriptions that an app created.
 /// </summary>
 /// <remarks>
+/// <para>
+/// By default, this uses the <see cref="TwitchApiIdentity.Default"/> and will only get subscriptions using <see cref="WebhookSubscriptionTransport"/> and <see cref="ConduitSubscriptionTransport"/>.
+/// To get subscriptions using <see cref="WebsocketSubscriptionTransport"/>, call the <see cref="ForWebsocketSubscriptions(UserIdentity)"/> method with an explicit <see cref="UserIdentity"/>.
+/// </para>
 /// If using <see cref="WebhookSubscriptionTransport"/> or <see cref="ConduitSubscriptionTransport"/>, requires an app access token.
 /// If using <see cref="WebsocketSubscriptionTransport"/>, requires a user access token.
 /// <br/>
@@ -29,6 +33,17 @@ public record GetEventSubSubscriptionsRequest
             .Add("user_id", UserId)
             .Add("subscription_id", SubscriptionId)
             .Add("after", After?.ToString());
+
+    /// <summary>
+    /// Configures the request to query for subscriptions using the <see cref="EventSubTransportMethod.Websocket"/>.
+    /// </summary>
+    /// <remarks>
+    /// This requires a user access token, so you must pass a <see cref="UserIdentity"/> to use for the request.
+    /// </remarks>
+    /// <param name="user">The <see cref="UserIdentity"/> to make the request as.</param>
+    /// <returns>A new <see cref="GetEventSubSubscriptionsRequest"/> configured to get subscriptions using <see cref="EventSubTransportMethod.Websocket"/>.</returns>
+    public GetEventSubSubscriptionsRequest ForWebsocketSubscriptions(UserIdentity user)
+        => this with { Identity = user };
 
     /// <summary>
     /// Specify this parameter to filter the returned list by subscription status.

--- a/TwitchySharp.Api/Helix/EventSub/EventSubIdentityResolver.cs
+++ b/TwitchySharp.Api/Helix/EventSub/EventSubIdentityResolver.cs
@@ -18,7 +18,7 @@ public static class EventSubIdentityResolver
     private static ImmutableDictionary<EventSubSubscriptionType, ConditionKey> AuthorizingUserConditionKeys { get; }
         = UserAuthorizedSubscriptionTypes
             .Select(RuntimeHelpers.GetUninitializedObject)
-            .OfType<IUserAuthorizedSubscriptionType>() // Cast here?
+            .OfType<IUserAuthorizedSubscriptionType>()
             .ToImmutableDictionary(st => st.Type, st => st.AuthorizingUserConditionKey);
 
     private static IEnumerable<Type> UserAuthorizedSubscriptionTypes =>

--- a/TwitchySharp.Api/Helix/EventSub/EventSubIdentityResolver.cs
+++ b/TwitchySharp.Api/Helix/EventSub/EventSubIdentityResolver.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Helix.EventSub;
+
+public static class EventSubIdentityResolver
+{
+    /// <summary>
+    /// Lookup map for the <see cref="ConditionKey"/> pointing to the user that requires authoriziation in an <see cref="EventSubSubscriptionCondition"/>.
+    /// </summary>
+    private static ImmutableDictionary<EventSubSubscriptionType, ConditionKey> AuthorizingUserConditionKeys { get; }
+        = UserAuthorizedSubscriptionTypes
+            .Select(RuntimeHelpers.GetUninitializedObject)
+            .OfType<IUserAuthorizedSubscriptionType>() // Cast here?
+            .ToImmutableDictionary(st => st.Type, st => st.AuthorizingUserConditionKey);
+
+    private static IEnumerable<Type> UserAuthorizedSubscriptionTypes =>
+        typeof(IUserAuthorizedSubscriptionType).Assembly
+            .GetTypes()
+            .Where(t =>
+                t.Namespace == typeof(UserUpdate).Namespace // All subscription types should be in same namespace.
+                && t.IsClass
+                && !t.IsAbstract
+                && !t.IsGenericTypeDefinition
+                && typeof(IUserAuthorizedSubscriptionType).IsAssignableFrom(t)
+                );
+
+    /// <summary>
+    /// Gets the authorizing user identity from an EventSub subscription, if one exists.
+    /// </summary>
+    /// <remarks>
+    /// This is resolved from the <see cref="EventSubSubscription.Condition"/> on a subscription type basis.
+    /// </remarks>
+    /// <param name="subscription">The subscription to get the authorizing user for.</param>
+    /// <returns>A <see cref="UserIdentity"/> indicating the Twitch user that authorized the subscription, if applicable.</returns>
+    public static UserIdentity? GetAuthorizingUser(this EventSubSubscription subscription)
+        => AuthorizingUserConditionKeys.TryGetValue(subscription.GetSubscriptionType(), out ConditionKey key) switch
+        {
+            true => subscription.Condition.TryGetValue(key, out string? userId) switch
+            {
+                true => new UserIdentity(new UserId(userId)),
+                false => null
+            },
+            false => null
+        };
+}

--- a/TwitchySharp.Api/Helix/EventSub/Interfaces/IEventSubSubscriptionType.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Interfaces/IEventSubSubscriptionType.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.Models;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 
 namespace TwitchySharp.Api.Helix.EventSub;
 /// <summary>
@@ -8,17 +8,15 @@ namespace TwitchySharp.Api.Helix.EventSub;
 public interface IEventSubSubscriptionType
 {
     /// <summary>
-    /// The type name of the subscription that will be created.
+    /// The type of the subscription, combining name and version.
+    /// </summary>
+    /// <remarks>
     /// See <see href="https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#subscription-types">Subscription Types</see>.
-    /// </summary>
-    EventSubSubscriptionTypeName Name { get; } // Twitch API uses "type", but we will use "Name" as "Type" encompasses the name + version of the subscription.
+    /// </remarks>
+    EventSubSubscriptionType Type { get; }
     /// <summary>
-    /// The version number that identifies the definition of the subscription type that the response will use.
-    /// </summary>
-    EventSubSubscriptionTypeVersion Version { get; }
-    /// <summary>
-    /// A dictionary that contains the parameter values that are specific to the specified subscription type. 
-    /// For the object’s required and optional fields, see the subscription type’s documentation.
+    /// A dictionary that contains the parameter values that are specific to the specified subscription type.
+    /// For the object's required and optional fields, see the subscription type's documentation.
     /// </summary>
     IReadOnlyDictionary<string, object> Condition { get; } // All conditions currently use string values, however it is possible that one may eventually appear with a non-string value, so let's use object here.
 }

--- a/TwitchySharp.Api/Helix/EventSub/Interfaces/IEventSubSubscriptionType.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Interfaces/IEventSubSubscriptionType.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub;
 using TwitchySharp.Shared.EventSub.Enums;
 
 namespace TwitchySharp.Api.Helix.EventSub;
@@ -18,5 +19,5 @@ public interface IEventSubSubscriptionType
     /// A dictionary that contains the parameter values that are specific to the specified subscription type.
     /// For the object's required and optional fields, see the subscription type's documentation.
     /// </summary>
-    IReadOnlyDictionary<string, object> Condition { get; } // All conditions currently use string values, however it is possible that one may eventually appear with a non-string value, so let's use object here.
+    IReadOnlyDictionary<ConditionKey, object> Condition { get; } // All conditions currently use string values, however it is possible that one may eventually appear with a non-string value, so let's use object here.
 }

--- a/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
+using TwitchySharp.Shared.EventSub;
+
+namespace TwitchySharp.Api.Helix.EventSub;
+
+/// <summary>
+/// An EventSub subscription type that requires user authorization.
+/// </summary>
+/// <remarks>
+/// These subscription types require a user access token with the specified scopes.
+/// The authorizing user must match the condition key specified by <see cref="AuthorizingUserConditionKey"/>.
+/// </remarks>
+public interface IUserAuthorizedSubscriptionType : IEventSubSubscriptionType
+{
+    /// <summary>
+    /// The condition key that identifies which user must authorize this subscription.
+    /// </summary>
+    ConditionKey AuthorizingUserConditionKey { get; }
+
+    /// <summary>
+    /// The scopes required for user authorization.
+    /// </summary>
+    IEnumerable<Scope> ValidScopes { get; }
+}

--- a/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
@@ -38,8 +38,10 @@ internal static class UserAuthorizedSubscriptionTypeExtensions
     internal static UserIdentity? GetAuthorizingUser(this IUserAuthorizedSubscriptionType subscriptionType)
     {
         var conditionKey = subscriptionType.AuthorizingUserConditionKey;
-        if (!subscriptionType.Condition.TryGetValue(conditionKey, out var userId))
+        if (!subscriptionType.Condition.TryGetValue(conditionKey, out object? value))
             return null;
-        return new UserIdentity(new UserId(userId?.ToString() ?? string.Empty));
+        if (value is not UserId userId)
+            return null;
+        return new UserIdentity(userId);
     }
 }

--- a/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Interfaces/IUserAuthorizedSubscriptionType.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub;
 
@@ -22,4 +23,23 @@ public interface IUserAuthorizedSubscriptionType : IEventSubSubscriptionType
     /// The scopes required for user authorization.
     /// </summary>
     IEnumerable<Scope> ValidScopes { get; }
+}
+
+internal static class UserAuthorizedSubscriptionTypeExtensions
+{
+    /// <summary>
+    /// Gets the authorizing user identity from the subscription type's condition.
+    /// </summary>
+    /// <param name="subscriptionType">The subscription type to get the authorizing user from.</param>
+    /// <returns>
+    /// A <see cref="UserIdentity"/> for the authorizing user, or <see langword="null"/>
+    /// if the condition key is not found in the subscription's condition.
+    /// </returns>
+    internal static UserIdentity? GetAuthorizingUser(this IUserAuthorizedSubscriptionType subscriptionType)
+    {
+        var conditionKey = subscriptionType.AuthorizingUserConditionKey;
+        if (!subscriptionType.Condition.TryGetValue(conditionKey, out var userId))
+            return null;
+        return new UserIdentity(new UserId(userId?.ToString() ?? string.Empty));
+    }
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
@@ -59,3 +59,17 @@ public record EventSubSubscription
     /// </remarks>
     public required int Cost { get; init; }
 }
+
+public static class EventSubSubscriptionExtensions
+{
+    /// <summary>
+    /// Get a <see cref="EventSubSubscriptionType"/> based on the type name and version of the subscription.
+    /// </summary>
+    /// <param name="subscription">The subscription to get the subscription type of.</param>
+    /// <returns>The <see cref="EventSubSubscriptionType"/> of the subscription.</returns>
+    public static EventSubSubscriptionType GetSubscriptionType(this EventSubSubscription subscription)
+        => new(subscription.Type, subscription.Version);
+
+    internal static bool RequiresUserAccessToken(this EventSubSubscription subscription)
+        => subscription.Transport.Method == EventSubTransportMethod.Websocket;
+}

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using TwitchySharp.Shared.EventSub;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
@@ -41,7 +42,7 @@ public record EventSubSubscription
     /// <remarks>
     /// The exact keys depend on what the subscription type expects.
     /// </remarks>
-    public required ImmutableDictionary<string, string> Condition { get; init; }
+    public required ImmutableDictionary<ConditionKey, string> Condition { get; init; }
     /// <summary>
     /// The date and time when the subscription was created.
     /// </summary>

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionCondition.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionCondition.cs
@@ -2,17 +2,18 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub;
 
 internal record EventSubSubscriptionCondition
-    : IReadOnlyDictionary<string, object>
+    : IReadOnlyDictionary<ConditionKey, object>
 {
-    private readonly ImmutableDictionary<string, object> _condition;
+    private readonly ImmutableDictionary<ConditionKey, object> _condition;
 
     public EventSubSubscriptionCondition()
-        => _condition = ImmutableDictionary<string, object>.Empty;
-    private EventSubSubscriptionCondition(ImmutableDictionary<string, object> condition)
+        => _condition = ImmutableDictionary<ConditionKey, object>.Empty;
+    private EventSubSubscriptionCondition(ImmutableDictionary<ConditionKey, object> condition)
         => _condition = condition;
 
     /// <summary>
@@ -21,23 +22,23 @@ internal record EventSubSubscriptionCondition
     /// <param name="conditionName">The name of the condition.</param>
     /// <param name="conditionValue">The value to set the condition to. If null, the condition is skipped.</param>
     /// <returns>This instance.</returns>
-    public EventSubSubscriptionCondition Set(string conditionName, object? conditionValue)
+    public EventSubSubscriptionCondition Set(ConditionKey conditionName, object? conditionValue)
         => conditionValue is null ? this : new EventSubSubscriptionCondition(_condition.SetItem(conditionName, conditionValue));
 
     #region IReadOnlyDictionary
-    public object this[string key] => ((IReadOnlyDictionary<string, object>)_condition)[key];
+    public object this[ConditionKey key] => ((IReadOnlyDictionary<ConditionKey, object>)_condition)[key];
 
-    public IEnumerable<string> Keys => _condition.Keys;
+    public IEnumerable<ConditionKey> Keys => _condition.Keys;
 
     public IEnumerable<object> Values => _condition.Values;
 
     public int Count => _condition.Count;
 
-    public bool ContainsKey(string key) => _condition.ContainsKey(key);
+    public bool ContainsKey(ConditionKey key) => _condition.ContainsKey(key);
 
-    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, object>>)_condition).GetEnumerator();
+    public IEnumerator<KeyValuePair<ConditionKey, object>> GetEnumerator() => ((IEnumerable<KeyValuePair<ConditionKey, object>>)_condition).GetEnumerator();
 
-    public bool TryGetValue(string key, [MaybeNullWhen(false)] out object value) => _condition.TryGetValue(key, out value);
+    public bool TryGetValue(ConditionKey key, [MaybeNullWhen(false)] out object value) => _condition.TryGetValue(key, out value);
 
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_condition).GetEnumerator();
     #endregion

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionSpecification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionSpecification.cs
@@ -2,7 +2,7 @@
 
 namespace TwitchySharp.Api.Helix.EventSub;
 
-public record NewEventSubSubscription
+public record EventSubSubscriptionSpecification
 {
     /// <summary>
     /// The type of subscription to create.
@@ -13,16 +13,16 @@ public record NewEventSubSubscription
     /// The transport type that you want Twitch to use when sending you notifications.
     /// Possible transport types are <see cref="WebhookSubscriptionTransport"/>, <see cref="WebsocketSubscriptionTransport"/>, and <see cref="ConduitSubscriptionTransport"/>.
     /// </summary>
-    public required NewEventSubSubscriptionTransport Transport { get; set; }
+    public required EventSubSubscriptionTransportSpecification Transport { get; set; }
 }
 
-internal static class NewEventSubSubscriptionExtensions
+internal static class EventSubSubscriptionSpecificationExtensions
 {
     /// <summary>
     /// Determines whether the subscription requires a user access token.
     /// </summary>
     /// <param name="subscription">The subscription to check.</param>
     /// <returns><see langword="true"/> if the subscription uses WebSocket transport; otherwise, <see langword="false"/>.</returns>
-    internal static bool RequiresUserAccessToken(this NewEventSubSubscription subscription)
+    internal static bool RequiresUserAccessToken(this EventSubSubscriptionSpecification subscription)
         => subscription.Transport.Method == EventSubTransportMethod.Websocket;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/NewEventSubSubscription.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/NewEventSubSubscription.cs
@@ -1,9 +1,11 @@
-﻿namespace TwitchySharp.Api.Helix.EventSub;
+﻿using TwitchySharp.Shared.EventSub.Enums;
+
+namespace TwitchySharp.Api.Helix.EventSub;
 
 public record NewEventSubSubscription
 {
     /// <summary>
-    /// The type of subscription to create. 
+    /// The type of subscription to create.
     /// See the <see cref="EventSub.Types"/> namespace for built-in subscription types.
     /// </summary>
     public required IEventSubSubscriptionType Type { get; set; }
@@ -12,4 +14,15 @@ public record NewEventSubSubscription
     /// Possible transport types are <see cref="WebhookSubscriptionTransport"/>, <see cref="WebsocketSubscriptionTransport"/>, and <see cref="ConduitSubscriptionTransport"/>.
     /// </summary>
     public required NewEventSubSubscriptionTransport Transport { get; set; }
+}
+
+internal static class NewEventSubSubscriptionExtensions
+{
+    /// <summary>
+    /// Determines whether the subscription requires a user access token.
+    /// </summary>
+    /// <param name="subscription">The subscription to check.</param>
+    /// <returns><see langword="true"/> if the subscription uses WebSocket transport; otherwise, <see langword="false"/>.</returns>
+    internal static bool RequiresUserAccessToken(this NewEventSubSubscription subscription)
+        => subscription.Transport.Method == EventSubTransportMethod.Websocket;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodMessageHold(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_MESSAGE_HOLD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageHold;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodMessageHold(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageHold;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorManageAutomod ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHold.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 
@@ -21,7 +22,7 @@ public sealed record AutomodMessageHold(UserId BroadcasterUserId, UserId Moderat
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user is notified if a message is caught by automod for review. 
+/// A user is notified if a message is caught by automod for review.
 /// Only public blocked terms trigger notifications, not private ones.
 /// </summary>
 /// <remarks>
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodMessageHoldV2(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_MESSAGE_HOLD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageHoldV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record AutomodMessageHoldV2(UserId BroadcasterUserId, UserId Moder
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageHoldV2.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -15,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodMessageHoldV2(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageHoldV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorManageAutomod ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -14,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodMessageUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorManageAutomod ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -15,8 +15,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodMessageUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_MESSAGE_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -19,7 +20,7 @@ public sealed record AutomodMessageUpdate(UserId BroadcasterUserId, UserId Moder
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -19,7 +20,7 @@ public sealed record AutomodMessageUpdateV2(UserId BroadcasterUserId, UserId Mod
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -15,8 +15,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodMessageUpdateV2(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_MESSAGE_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageUpdateV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Message/AutomodMessageUpdateV2.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -14,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodMessageUpdateV2(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodMessageUpdateV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorManageAutomod ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
@@ -15,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodSettingsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodSettingsUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadAutomodSettings ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record AutomodSettingsUpdate(UserId BroadcasterUserId, UserId Mode
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Settings/AutomodSettingsUpdate.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A notification is sent when a broadcaster’s automod settings are updated.
+/// A notification is sent when a broadcaster's automod settings are updated.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ModeratorReadAutomodSettings"/>.
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodSettingsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_SETTINGS_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodSettingsUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record AutomodTermsUpdate(UserId BroadcasterUserId, UserId Moderat
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A notification is sent when a broadcaster’s automod terms are updated. Changes to private terms are not sent.
+/// A notification is sent when a broadcaster's automod terms are updated. Changes to private terms are not sent.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ModeratorManageAutomod"/>.
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record AutomodTermsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.AUTOMOD_TERMS_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodTermsUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Automod/Terms/AutomodTermsUpdate.cs
@@ -15,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel).</param>
 /// <param name="ModeratorUserId">User id of a moderator in the broadcaster's chat. This can also be the broadcaster.</param>
 public sealed record AutomodTermsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.AutomodTermsUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorManageAutomod ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
@@ -13,9 +13,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster that you want to get Channel Ad Break begin notifications for.</param>
 public sealed record ChannelAdBreakBegin(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelAdBreakBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadAds ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -14,8 +14,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelAdBreakBegin(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_AD_BREAK_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelAdBreakBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/AdBreak/ChannelAdBreakBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -18,6 +19,6 @@ public sealed record ChannelAdBreakBegin(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
@@ -21,9 +21,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to get Bits Use notifications for.</param>
 public sealed record ChannelBitsUse(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelBitsUse;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.BitsRead ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Api.Authorization;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -26,6 +27,6 @@ public sealed record ChannelBitsUse(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Bits/ChannelBitsUse.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Api.Authorization;
 
@@ -22,8 +22,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelBitsUse(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_BITS_USE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelBitsUse;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This must have created a user access token including <see cref="Scope.ChannelModerate"/> for this application.
 /// </param>
 public sealed record ChannelBan(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelBan;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelModerate ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelBan(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_BAN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelBan;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelBan.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelBan(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelCheer(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.BitsRead"/> for this application.
 /// </param>
 public sealed record ChannelCheer(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelCheer;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.BitsRead ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelCheer.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelCheer(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHEER);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelCheer;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record ChannelFollow(UserId BroadcasterUserId, UserId ModeratorUse
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
@@ -15,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster whose channel you want to get follow notifications for.</param>
 /// <param name="ModeratorUserId">The ID of a moderator of the channel you want to get follow notifications for. If you have authorization from the broadcaster rather than a moderator, specify the broadcaster's user ID here.</param>
 public sealed record ChannelFollow(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadFollowers ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelFollow.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -12,12 +12,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// The user who created the access token must be the same user as the <paramref name="ModeratorUserId"/>.
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster whose channel you want to get follow notifications for.</param>
-/// <param name="ModeratorUserId">The ID of a moderator of the channel you want to get follow notifications for. If you have authorization from the broadcaster rather than a moderator, specify the broadcaster’s user ID here.</param>
+/// <param name="ModeratorUserId">The ID of a moderator of the channel you want to get follow notifications for. If you have authorization from the broadcaster rather than a moderator, specify the broadcaster's user ID here.</param>
 public sealed record ChannelFollow(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_FOLLOW);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -30,8 +30,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelModerate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_MODERATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModerate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -34,7 +35,7 @@ public sealed record ChannelModerate(UserId BroadcasterUserId, UserId ModeratorU
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerate.cs
@@ -29,9 +29,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application with the required scopes.
 /// </param>
 public sealed record ChannelModerate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModerate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadBlockedTerms, Scope.ModeratorReadChatSettings, Scope.ModeratorReadUnbanRequests, Scope.ModeratorReadBannedUsers, Scope.ModeratorReadChatMessages, Scope.ModeratorReadModerators, Scope.ModeratorReadVips ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -32,8 +32,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelModerateV2(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_MODERATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModerateV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
@@ -31,9 +31,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application with the required scopes.
 /// </param>
 public sealed record ChannelModerateV2(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModerateV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadBlockedTerms, Scope.ModeratorReadChatSettings, Scope.ModeratorReadUnbanRequests, Scope.ModeratorReadBannedUsers, Scope.ModeratorReadChatMessages, Scope.ModeratorReadWarnings, Scope.ModeratorReadModerators, Scope.ModeratorReadVips ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelModerateV2.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -36,7 +37,7 @@ public sealed record ChannelModerateV2(UserId BroadcasterUserId, UserId Moderato
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record ChannelPointsAutomaticRewardRedemptionAdd(UserId Broadcaste
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -12,9 +13,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points reward add notifications for.</param>
 public sealed record ChannelPointsAutomaticRewardRedemptionAdd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsAutomaticRewardRedemptionAdd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAdd.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsAutomaticRewardRedemptionAdd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsAutomaticRewardRedemptionAdd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Api.Authorization;
 
@@ -15,8 +15,7 @@ namespace TwitchySharp.Api.Helix.EventSub.Models.SubscriptionTypes.Channel.Chann
 public sealed record ChannelPointsAutomaticRewardRedemptionAddV2(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsAutomaticRewardRedemptionAddV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Api.Authorization;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.Models.SubscriptionTypes.Channel.ChannelPoints;
 
@@ -19,6 +20,6 @@ public sealed record ChannelPointsAutomaticRewardRedemptionAddV2(UserId Broadcas
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsAutomaticRewardRedemptionAddV2.cs
@@ -14,9 +14,11 @@ namespace TwitchySharp.Api.Helix.EventSub.Models.SubscriptionTypes.Channel.Chann
 /// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive Channel Points Reward Add V2 notifications for.</param>
 public sealed record ChannelPointsAutomaticRewardRedemptionAddV2(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsAutomaticRewardRedemptionAddV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -14,6 +15,6 @@ public sealed record ChannelPointsCustomRewardAdd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -10,8 +10,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsCustomRewardAdd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_CUSTOM_REWARD_ADD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardAdd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardAdd.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -7,11 +8,16 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// A custom channel points reward has been created for the specified channel.
 /// </summary>
+/// <remarks>
+/// Requires a user access token that includes <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
+/// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward add notifications for.</param>
 public sealed record ChannelPointsCustomRewardAdd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardAdd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -15,7 +16,7 @@ public sealed record ChannelPointsCustomRewardRedemptionAdd(UserId BroadcasterUs
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("reward_id", RewardId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("reward_id"), RewardId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -7,12 +8,17 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// A viewer has redeemed a custom channel points reward on the specified channel.
 /// </summary>
+/// <remarks>
+/// Requires a user access token that includes <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
+/// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward redemption add notifications for.</param>
 /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
 public sealed record ChannelPointsCustomRewardRedemptionAdd(UserId BroadcasterUserId, string? RewardId = null)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRedemptionAdd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionAdd.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,8 +11,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsCustomRewardRedemptionAdd(UserId BroadcasterUserId, string? RewardId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name => new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_AUTOMATIC_REWARD_REDEMPTION_ADD);
-    public EventSubSubscriptionTypeVersion Version => new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRedemptionAdd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,8 +11,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsCustomRewardRedemptionUpdate(UserId BroadcasterUserId, string? RewardId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_CUSTOM_REWARD_REDEMPTION_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRedemptionUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -7,12 +8,17 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// A redemption of a channel points custom reward has been updated for the specified channel.
 /// </summary>
+/// <remarks>
+/// Requires a user access token that includes <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
+/// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward redemption update notifications for.</param>
 /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
 public sealed record ChannelPointsCustomRewardRedemptionUpdate(UserId BroadcasterUserId, string? RewardId = null)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRedemptionUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRedemptionUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -15,7 +16,7 @@ public sealed record ChannelPointsCustomRewardRedemptionUpdate(UserId Broadcaste
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("reward_id", RewardId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("reward_id"), RewardId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -15,7 +16,7 @@ public sealed record ChannelPointsCustomRewardRemove(UserId BroadcasterUserId, s
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("reward_id", RewardId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("reward_id"), RewardId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -7,12 +8,17 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// A custom channel points reward has been removed from the specified channel.
 /// </summary>
+/// <remarks>
+/// Requires a user access token that includes <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
+/// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward remove notifications for.</param>
 /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
 public sealed record ChannelPointsCustomRewardRemove(UserId BroadcasterUserId, string? RewardId = null)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRemove;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardRemove.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,8 +11,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsCustomRewardRemove(UserId BroadcasterUserId, string? RewardId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_CUSTOM_REWARD_REMOVE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardRemove;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,8 +11,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPointsCustomRewardUpdate(UserId BroadcasterUserId, string? RewardId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POINTS_CUSTOM_REWARD_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -7,12 +8,17 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// A custom channel points reward has been updated for the specified channel.
 /// </summary>
+/// <remarks>
+/// Requires a user access token that includes <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
+/// </remarks>
 /// <param name="BroadcasterUserId">The broadcaster user ID for the channel you want to receive channel points custom reward update notifications for.</param>
 /// <param name="RewardId">Optional. Specify a reward id to only receive notifications for a specific reward.</param>
 public sealed record ChannelPointsCustomRewardUpdate(UserId BroadcasterUserId, string? RewardId = null)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPointsCustomRewardUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadRedemptions, Scope.ChannelManageRedemptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelPoints/ChannelPointsCustomRewardUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -15,7 +16,7 @@ public sealed record ChannelPointsCustomRewardUpdate(UserId BroadcasterUserId, s
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("reward_id", RewardId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("reward_id"), RewardId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelRaid.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelRaid.cs
@@ -1,23 +1,23 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A broadcaster raids another broadcaster’s channel.
+/// A broadcaster raids another broadcaster's channel.
 /// </summary>
 /// <remarks>
 /// No authorization required.
 /// You can use the built-in static methods <see cref="From(string)"/> and <see cref="To(string)"/> as well as provided extension methods of the same name to help create this subscription.
 /// </remarks>
 /// <param name="FromBroadcasterUserId">
-/// The broadcaster user ID that created the channel raid you want to get notifications for. 
-/// Use this parameter if you want to know when a specific broadcaster raids another broadcaster. 
+/// The broadcaster user ID that created the channel raid you want to get notifications for.
+/// Use this parameter if you want to know when a specific broadcaster raids another broadcaster.
 /// The channel raid condition must include either <paramref name="FromBroadcasterUserId"/> or <paramref name="ToBroadcasterUserId"/>.
 /// </param>
 /// <param name="ToBroadcasterUserId">
-/// The broadcaster user ID that received the channel raid you want to get notifications for. 
-/// Use this parameter if you want to know when a specific broadcaster is raided by another broadcaster. 
+/// The broadcaster user ID that received the channel raid you want to get notifications for.
+/// Use this parameter if you want to know when a specific broadcaster is raided by another broadcaster.
 /// The channel raid condition must include either <paramref name="FromBroadcasterUserId"/> or <paramref name="ToBroadcasterUserId"/>.
 /// </param>
 public sealed record ChannelRaid(UserId? ToBroadcasterUserId, UserId? FromBroadcasterUserId = null) // May need to remove this primary constuctor IF setting both conditions is not allowed.
@@ -41,8 +41,7 @@ public sealed record ChannelRaid(UserId? ToBroadcasterUserId, UserId? FromBroadc
     public static ChannelRaid To(UserId toBroadcasterUserId)
         => new(toBroadcasterUserId, null);
 
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_RAID);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelRaid;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelRaid.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelRaid.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -45,9 +46,9 @@ public sealed record ChannelRaid(UserId? ToBroadcasterUserId, UserId? FromBroadc
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("from_broadcaster_user_id", FromBroadcasterUserId)
-            .Set("to_broadcaster_user_id", ToBroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("from_broadcaster_user_id"), FromBroadcasterUserId)
+            .Set(new ConditionKey("to_broadcaster_user_id"), ToBroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }
 
 public static class ChannelRaidFluentExtensions

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelSubscribe(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadSubscriptions"/> for this application.
 /// </param>
 public sealed record ChannelSubscribe(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscribe;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadSubscriptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelSubscribe.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSubscribe(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUBSCRIBE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscribe;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelUnban(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_UNBAN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnban;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelUnban(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUnban.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This must have created a user access token including <see cref="Scope.ChannelModerate"/> for this application.
 /// </param>
 public sealed record ChannelUnban(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnban;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelModerate ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record ChannelUpdate(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChannelUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelUpdate(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignProgress.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -14,6 +15,6 @@ public sealed record CharityCampaignProgress(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignProgress.cs
@@ -1,17 +1,16 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// Sends an event notification when progress is made towards the campaign’s goal or when the broadcaster changes the fundraising goal.
+/// Sends an event notification when progress is made towards the campaign's goal or when the broadcaster changes the fundraising goal.
 /// </summary>
 /// <param name="BroadcasterUserId">The ID of the broadcaster that you want to receive notifications about when their campaign makes progress or is updated.</param>
 public sealed record CharityCampaignProgress(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHARITY_CAMPAIGN_PROGRESS);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.CharityCampaignProgress;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStart.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStart.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -14,6 +15,6 @@ public sealed record CharityCampaignStart(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStart.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStart.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -10,8 +10,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record CharityCampaignStart(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHARITY_CAMPAIGN_START);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.CharityCampaignStart;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStop.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStop.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -14,6 +15,6 @@ public sealed record CharityCampaignStop(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStop.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityCampaignStop.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -10,8 +10,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record CharityCampaignStop(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHARITY_CAMPAIGN_STOP);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.CharityCampaignStop;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityDonation.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityDonation.cs
@@ -1,17 +1,16 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// Sends an event notification when a user donates to the broadcaster’s charity campaign.
+/// Sends an event notification when a user donates to the broadcaster's charity campaign.
 /// </summary>
 /// <param name="BroadcasterUserId">The ID of the broadcaster that you want to receive notifications about when users donate to their campaign.</param>
 public sealed record CharityDonation(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHARITY_DONATION);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.CharityDonation;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityDonation.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/CharityCampaign/CharityDonation.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -14,6 +15,6 @@ public sealed record CharityDonation(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatClear(UserId BroadcasterUserId, UserId UserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatClear(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_CLEAR);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatClear;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClear.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to receive chat clear events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatClear(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatClear;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatClearUserMessages(UserId BroadcasterUserId, User
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User ID of the channel to receive chat clear user messages events for.</param>
 /// <param name="UserId">The user ID to read chat as.</param>
 public sealed record ChannelChatClearUserMessages(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatClearUserMessages;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatClearUserMessages.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatClearUserMessages(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_CLEAR_USER_MESSAGES);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatClearUserMessages;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatMessage(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_MESSAGE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatMessage;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The User ID of the channel to receive chat message events for.</param>
 /// <param name="UserId">The User ID to read chat as.</param>
 public sealed record ChannelChatMessage(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatMessage;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessage.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatMessage(UserId BroadcasterUserId, UserId UserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatMessageDelete(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_MESSAGE_DELETE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatMessageDelete;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatMessageDelete(UserId BroadcasterUserId, UserId U
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatMessageDelete.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">User id of the broadcaster (channel) to receive chat message delete events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatMessageDelete(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatMessageDelete;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to receive chat notification events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatNotification(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatNotification;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatNotification(UserId BroadcasterUserId, UserId Us
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatNotification.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatNotification(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_NOTIFICATION);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatNotification;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatUserMessageHold(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_USER_MESSAGE_HOLD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatUserMessageHold;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatUserMessageHold(UserId BroadcasterUserId, UserId
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageHold.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to receive chat message events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatUserMessageHold(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatUserMessageHold;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user is notified if their message’s automod status is updated.
+/// A user is notified if their message's automod status is updated.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.UserReadChat"/>, or
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatUserMessageUpdate(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_USER_MESSAGE_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatUserMessageUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,7 +22,7 @@ public sealed record ChannelChatUserMessageUpdate(UserId BroadcasterUserId, User
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Chat/ChannelChatUserMessageUpdate.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to receive chat message update events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatUserMessageUpdate(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatUserMessageUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelChatSettingsUpdate(UserId BroadcasterUserId, UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_CHAT_SETTINGS_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatSettingsUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -15,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) to receive chat settings update events for.</param>
 /// <param name="UserId">The user id of the user to read chat as.</param>
 public sealed record ChannelChatSettingsUpdate(UserId BroadcasterUserId, UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelChatSettingsUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadChat ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ChatSettings/ChannelChatSettingsUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record ChannelChatSettingsUpdate(UserId BroadcasterUserId, UserId 
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalBegin(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGoals ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,14 +11,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// Requires a user access token that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </remarks>
 /// <param name="BroadcasterUserId">
-/// The user id of the broadcaster to get notified about. 
+/// The user id of the broadcaster to get notified about.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalBegin(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.GOAL_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record GoalBegin(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record GoalEnd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,14 +11,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// Requires a user access token that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </remarks>
 /// <param name="BroadcasterUserId">
-/// The user id of the broadcaster to get notified about. 
+/// The user id of the broadcaster to get notified about.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalEnd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.GOAL_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalEnd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalEnd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGoals ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,6 +23,6 @@ public sealed record GoalProgress(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
@@ -1,25 +1,24 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// Get notified when progress (either positive or negative) is made towards a broadcaster’s goal.
+/// Get notified when progress (either positive or negative) is made towards a broadcaster's goal.
 /// Note that it is possible to receive this event before receiving a <see cref="GoalBegin"/> event.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </remarks>
 /// <param name="BroadcasterUserId">
-/// The user id of the broadcaster to get notified about. 
+/// The user id of the broadcaster to get notified about.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalProgress(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.GOAL_PROGRESS);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalProgress;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Goals/GoalProgress.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ChannelReadGoals"/>.
 /// </param>
 public sealed record GoalProgress(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.GoalProgress;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGoals ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -14,8 +14,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelGuestStarGuestUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_GUEST_STAR_GUEST_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.BETA);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarGuestUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -13,9 +14,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) hosting the Guest Star Session.</param>
 /// <param name="ModeratorUserId">The user id of the broadcaster or a moderator of the specified broadcaster.</param>
 public sealed record ChannelGuestStarGuestUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarGuestUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGuestStar, Scope.ChannelManageGuestStar, Scope.ModeratorReadGuestStar, Scope.ModeratorManageGuestStar ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarGuestUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -18,7 +19,7 @@ public sealed record ChannelGuestStarGuestUpdate(UserId BroadcasterUserId, UserI
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
@@ -14,9 +14,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) hosting the Guest Star Session.</param>
 /// <param name="ModeratorUserId">The user id of the broadcaster or a moderator of the specified broadcaster.</param>
 public sealed record ChannelGuestStarSessionBegin(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSessionBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGuestStar, Scope.ChannelManageGuestStar, Scope.ModeratorReadGuestStar, Scope.ModeratorManageGuestStar ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -19,7 +20,7 @@ public sealed record ChannelGuestStarSessionBegin(UserId BroadcasterUserId, User
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -15,8 +15,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelGuestStarSessionBegin(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_GUEST_STAR_SESSION_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.BETA);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSessionBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,7 +21,7 @@ public sealed record ChannelGuestStarSessionEnd(UserId BroadcasterUserId, UserId
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelGuestStarSessionEnd(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_GUEST_STAR_SESSION_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.BETA);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSessionEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSessionEnd.cs
@@ -15,9 +15,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) hosting the Guest Star Session.</param>
 /// <param name="ModeratorUserId">The user id of the broadcaster or a moderator of the specified broadcaster.</param>
 public sealed record ChannelGuestStarSessionEnd(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSessionEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGuestStar, Scope.ChannelManageGuestStar, Scope.ModeratorReadGuestStar, Scope.ModeratorManageGuestStar ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -14,8 +14,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelGuestStarSettingsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_GUEST_STAR_SETTINGS_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.BETA);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSettingsUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -18,7 +19,7 @@ public sealed record ChannelGuestStarSettingsUpdate(UserId BroadcasterUserId, Us
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/GuestStar/ChannelGuestStarSettingsUpdate.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 using TwitchySharp.Shared.EventSub;
@@ -13,9 +14,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) hosting the Guest Star Session.</param>
 /// <param name="ModeratorUserId">The user id of the broadcaster or a moderator of the specified broadcaster.</param>
 public sealed record ChannelGuestStarSettingsUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelGuestStarSettingsUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadGuestStar, Scope.ChannelManageGuestStar, Scope.ModeratorReadGuestStar, Scope.ModeratorManageGuestStar ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 
@@ -22,6 +23,6 @@ public sealed record HypeTrainBeginV2(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have also created a user access token including <see cref="Scope.ChannelReadHypeTrain"/> for your application.
 /// </param>
 public sealed record HypeTrainBeginV2(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainBeginV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadHypeTrain ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainBeginV2.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record HypeTrainBeginV2(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.HYPE_TRAIN_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainBeginV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have also created a user access token including <see cref="Scope.ChannelReadHypeTrain"/> for your application.
 /// </param>
 public sealed record HypeTrainEndV2(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainEndV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadHypeTrain ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record HypeTrainEndV2(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.HYPE_TRAIN_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainEndV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainEndV2.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 
@@ -22,6 +23,6 @@ public sealed record HypeTrainEndV2(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have also created a user access token including <see cref="Scope.ChannelReadHypeTrain"/> for your application.
 /// </param>
 public sealed record HypeTrainProgressV2(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainProgressV2;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadHypeTrain ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 
@@ -22,6 +23,6 @@ public sealed record HypeTrainProgressV2(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/HypeTrain/HypeTrainProgressV2.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record HypeTrainProgressV2(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.HYPE_TRAIN_PROGRESS);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V2);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.HypeTrainProgressV2;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelModeratorAdd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelModeratorAdd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_MODERATOR_ADD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModeratorAdd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorAdd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModerationRead"/> for your application.
 /// </param>
 public sealed record ChannelModeratorAdd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModeratorAdd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModerationRead ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelModeratorRemove(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModerationRead"/> for your application.
 /// </param>
 public sealed record ChannelModeratorRemove(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModeratorRemove;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModerationRead ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Moderator/ChannelModeratorRemove.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelModeratorRemove(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_MODERATOR_REMOVE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelModeratorRemove;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPollBegin(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POLL_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPollBegin(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollBegin.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPolls"/> or <see cref="Scope.ChannelManagePolls"/> for this application.
 /// </param>
 public sealed record ChannelPollBegin(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPolls, Scope.ChannelManagePolls ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPolls"/> or <see cref="Scope.ChannelManagePolls"/> for this application.
 /// </param>
 public sealed record ChannelPollEnd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPolls, Scope.ChannelManagePolls ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPollEnd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPollEnd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POLL_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPollProgress(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_POLL_PROGRESS);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollProgress;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPolls"/> or <see cref="Scope.ChannelManagePolls"/> for this application.
 /// </param>
 public sealed record ChannelPollProgress(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPollProgress;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPolls, Scope.ChannelManagePolls ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Polls/ChannelPollProgress.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPollProgress(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPredictionBegin(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_PREDICTION_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPredictions"/> or <see cref="Scope.ChannelManagePredictions"/> for this application.
 /// </param>
 public sealed record ChannelPredictionBegin(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPredictions, Scope.ChannelManagePredictions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPredictionBegin(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPredictionEnd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_PREDICTION_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPredictionEnd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionEnd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPredictions"/> or <see cref="Scope.ChannelManagePredictions"/> for this application.
 /// </param>
 public sealed record ChannelPredictionEnd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPredictions, Scope.ChannelManagePredictions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPredictionLock(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_PREDICTION_LOCK);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionLock;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPredictions"/> or <see cref="Scope.ChannelManagePredictions"/> for this application.
 /// </param>
 public sealed record ChannelPredictionLock(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionLock;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPredictions, Scope.ChannelManagePredictions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionLock.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPredictionLock(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ChannelReadPredictions"/> or <see cref="Scope.ChannelManagePredictions"/> for this application.
 /// </param>
 public sealed record ChannelPredictionProgress(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionProgress;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadPredictions, Scope.ChannelManagePredictions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelPredictionProgress(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Predictions/ChannelPredictionProgress.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelPredictionProgress(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_PREDICTION_PROGRESS);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelPredictionProgress;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionBegin.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record ChannelSharedChatSessionBegin(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionBegin.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSharedChatSessionBegin(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SHARED_CHAT_SESSION_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSharedChatSessionBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionEnd.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record ChannelSharedChatSessionEnd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionEnd.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSharedChatSessionEnd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SHARED_CHAT_SESSION_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSharedChatSessionEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionUpdate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record ChannelSharedChatSessionUpdate(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SharedChat/ChannelSharedChatSessionUpdate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSharedChatSessionUpdate(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SHARED_CHAT_SESSION_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSharedChatSessionUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShieldMode"/> or <see cref="Scope.ModeratorManageShieldMode"/>.
 /// </param>
 public sealed record ShieldModeBegin(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ShieldModeBegin;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadShieldMode, Scope.ModeratorManageShieldMode ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ShieldModeBegin(UserId BroadcasterUserId, UserId ModeratorU
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeBegin.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -12,14 +12,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) that you want to receive notifications about when they activate Shield Mode.</param>
 /// <param name="ModeratorUserId">
-/// The user id of the broadcaster or one of the broadcaster’s moderators.
+/// The user id of the broadcaster or one of the broadcaster's moderators.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShieldMode"/> or <see cref="Scope.ModeratorManageShieldMode"/>.
 /// </param>
 public sealed record ShieldModeBegin(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.SHIELD_MODE_BEGIN);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ShieldModeBegin;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ShieldModeEnd(UserId BroadcasterUserId, UserId ModeratorUse
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShieldMode"/> or <see cref="Scope.ModeratorManageShieldMode"/>.
 /// </param>
 public sealed record ShieldModeEnd(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ShieldModeEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadShieldMode, Scope.ModeratorManageShieldMode ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/ShieldMode/ShieldModeEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -12,14 +12,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) that you want to receive notifications about when they deactivate Shield Mode.</param>
 /// <param name="ModeratorUserId">
-/// The user id of the broadcaster or one of the broadcaster’s moderators.
+/// The user id of the broadcaster or one of the broadcaster's moderators.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShieldMode"/> or <see cref="Scope.ModeratorManageShieldMode"/>.
 /// </param>
 public sealed record ShieldModeEnd(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.SHIELD_MODE_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ShieldModeEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ShoutoutCreate(UserId BroadcasterUserId, UserId ModeratorUs
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -12,14 +12,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) that you want to receive notifications about when they send a Shoutout.</param>
 /// <param name="ModeratorUserId">
-/// The user id of the broadcaster or one of the broadcaster’s moderators.
+/// The user id of the broadcaster or one of the broadcaster's moderators.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShoutouts"/> or <see cref="Scope.ModeratorManageShoutouts"/>.
 /// </param>
 public sealed record ShoutoutCreate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.SHOUTOUT_CREATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ShoutoutCreate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutCreate.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShoutouts"/> or <see cref="Scope.ModeratorManageShoutouts"/>.
 /// </param>
 public sealed record ShoutoutCreate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ShoutoutCreate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadShoutouts, Scope.ModeratorManageShoutouts ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
@@ -1,26 +1,25 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
 /// Sends a notification when the specified broadcaster receives a Shoutout.
-/// <b>Note: </b> Sent only if Twitch posts the Shoutout to the broadcaster’s activity feed.
+/// <b>Note: </b> Sent only if Twitch posts the Shoutout to the broadcaster's activity feed.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ModeratorReadShoutouts"/> or <see cref="Scope.ModeratorManageShoutouts"/>.
 /// </remarks>
 /// <param name="BroadcasterUserId">The user id of the broadcaster (channel) that you want to receive notifications about when they receive a Shoutout.</param>
 /// <param name="ModeratorUserId">
-/// The user id of the broadcaster or one of the broadcaster’s moderators.
+/// The user id of the broadcaster or one of the broadcaster's moderators.
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShoutouts"/> or <see cref="Scope.ModeratorManageShoutouts"/>.
 /// </param>
 public sealed record ShoutoutReceived(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.SHOUTOUT_RECEIVED);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ShoutoutReceived;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -23,7 +24,7 @@ public sealed record ShoutoutReceived(UserId BroadcasterUserId, UserId Moderator
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Shoutout/ShoutoutReceived.cs
@@ -18,9 +18,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token for this application that includes <see cref="Scope.ModeratorReadShoutouts"/> or <see cref="Scope.ModeratorManageShoutouts"/>.
 /// </param>
 public sealed record ShoutoutReceived(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ShoutoutReceived;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadShoutouts, Scope.ModeratorManageShoutouts ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSubscriptionEnd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUBSCRIPTION_END);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionEnd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelSubscriptionEnd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionEnd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadSubscriptions"/> for this application.
 /// </param>
 public sealed record ChannelSubscriptionEnd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionEnd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadSubscriptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSubscriptionGift(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUBSCRIPTION_GIFT);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionGift;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadSubscriptions"/> for this application.
 /// </param>
 public sealed record ChannelSubscriptionGift(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionGift;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadSubscriptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionGift.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelSubscriptionGift(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadSubscriptions"/> for this application.
 /// </param>
 public sealed record ChannelSubscriptionMessage(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionMessage;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadSubscriptions ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSubscriptionMessage(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUBSCRIPTION_MESSAGE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSubscriptionMessage;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Subscription/ChannelSubscriptionMessage.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelSubscriptionMessage(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelSuspiciousUserMessage(UserId BroadcasterUserId, User
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("moderator_user_id", ModeratorUserId)
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId)
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModeratorReadSuspiciousUsers"/> for this application.
 /// </param>
 public sealed record ChannelSuspiciousUserMessage(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSuspiciousUserMessage;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadSuspiciousUsers ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserMessage.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSuspiciousUserMessage(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUSPICIOUS_USER_MESSAGE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSuspiciousUserMessage;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModeratorReadSuspiciousUsers"/> for this application.
 /// </param>
 public sealed record ChannelSuspiciousUserUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSuspiciousUserUpdate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadSuspiciousUsers ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelSuspiciousUserUpdate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_SUSPICIOUS_USER_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelSuspiciousUserUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/SuspiciousUser/ChannelSuspiciousUserUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelSuspiciousUserUpdate(UserId BroadcasterUserId, UserI
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("moderator_user_id", ModeratorUserId)
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId)
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelUnbanRequestCreate(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_UNBAN_REQUEST_CREATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnbanRequestCreate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelUnbanRequestCreate(UserId BroadcasterUserId, UserId 
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("moderator_user_id", ModeratorUserId)
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId)
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestCreate.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ModeratorReadUnbanRequests"/> or <see cref="Scope.ModeratorManageUnbanRequests"/> for this application.
 /// </param>
 public sealed record ChannelUnbanRequestCreate(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnbanRequestCreate;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadUnbanRequests, Scope.ModeratorManageUnbanRequests ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelUnbanRequestResolve(UserId ModeratorUserId, UserId B
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("moderator_user_id", ModeratorUserId)
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId)
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelUnbanRequestResolve(UserId ModeratorUserId, UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_UNBAN_REQUEST_RESOLVE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnbanRequestResolve;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/UnbanRequest/ChannelUnbanRequestResolve.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token including <see cref="Scope.ModeratorReadUnbanRequests"/> or <see cref="Scope.ModeratorManageUnbanRequests"/> for this application.
 /// </param>
 public sealed record ChannelUnbanRequestResolve(UserId ModeratorUserId, UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelUnbanRequestResolve;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadUnbanRequests, Scope.ModeratorManageUnbanRequests ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadVips"/> or <see cref="Scope.ChannelManageVips"/> for this application.
 /// </param>
 public sealed record ChannelVipAdd(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelVIPAdd;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadVips, Scope.ChannelManageVips ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelVipAdd(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipAdd.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelVipAdd(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_VIP_ADD);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelVIPAdd;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
@@ -16,9 +16,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ChannelReadVips"/> or <see cref="Scope.ChannelManageVips"/> for this application.
 /// </param>
 public sealed record ChannelVipRemove(UserId BroadcasterUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelVIPRemove;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("broadcaster_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ChannelReadVips, Scope.ChannelManageVips ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record ChannelVipRemove(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Vip/ChannelVipRemove.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -17,8 +17,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelVipRemove(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_VIP_REMOVE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelVIPRemove;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user acknowledges a warning. Broadcasters and moderators can see the warning’s details.
+/// A user acknowledges a warning. Broadcasters and moderators can see the warning's details.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ModeratorReadWarnings"/> or <see cref="Scope.ModeratorManageWarnings"/>.
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelWarningAcknowledgement(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_WARNING_ACKNOWLEDGEMENT);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelWarningAcknowledgement;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModeratorReadWarnings"/> or <see cref="Scope.ModeratorManageWarnings"/> for this application.
 /// </param>
 public sealed record ChannelWarningAcknowledgement(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelWarningAcknowledgement;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadWarnings, Scope.ModeratorManageWarnings ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningAcknowledgement.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelWarningAcknowledgement(UserId BroadcasterUserId, Use
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
@@ -1,11 +1,11 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user is sent a warning. Broadcasters and moderators can see the warning’s details.
+/// A user is sent a warning. Broadcasters and moderators can see the warning's details.
 /// </summary>
 /// <remarks>
 /// Requires a user access token that includes <see cref="Scope.ModeratorReadWarnings"/> or <see cref="Scope.ModeratorManageWarnings"/>.
@@ -18,8 +18,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ChannelWarningSend(UserId BroadcasterUserId, UserId ModeratorUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CHANNEL_WARNING_SEND);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelWarningSend;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,7 +23,7 @@ public sealed record ChannelWarningSend(UserId BroadcasterUserId, UserId Moderat
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId)
-            .Set("moderator_user_id", ModeratorUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId)
+            .Set(new ConditionKey("moderator_user_id"), ModeratorUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Channel/Warning/ChannelWarningSend.cs
@@ -17,9 +17,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// This user must have created a user access token that includes <see cref="Scope.ModeratorReadWarnings"/> or <see cref="Scope.ModeratorManageWarnings"/> for this application.
 /// </param>
 public sealed record ChannelWarningSend(UserId BroadcasterUserId, UserId ModeratorUserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelWarningSend;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.ModeratorReadWarnings, Scope.ModeratorManageWarnings ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Conduit/ConduitShardDisabled.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Conduit/ConduitShardDisabled.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -11,17 +11,16 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// If a <paramref name="ConduitId"/> is specified, the client id must be the owner of the conduit.
 /// </remarks>
 /// <param name="ClientId">
-/// The client id of the application to get conduit disabled notifications for. 
+/// The client id of the application to get conduit disabled notifications for.
 /// This application must have created the app access token used to make the request.
 /// </param>
 /// <param name="ConduitId">
-/// The conduit ID to receive events for. 
-/// If <see langword="null"/>, events for all of this client’s conduits are sent.</param>
+/// The conduit ID to receive events for.
+/// If <see langword="null"/>, events for all of this client's conduits are sent.</param>
 public sealed record ConduitShardDisabled(ClientId ClientId, ConduitId? ConduitId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.CONDUIT_SHARD_DISABLED);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ConduitShardDisabled;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Conduit/ConduitShardDisabled.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Conduit/ConduitShardDisabled.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -24,7 +25,7 @@ public sealed record ConduitShardDisabled(ClientId ClientId, ConduitId? ConduitI
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("client_id", ClientId)
-            .Set("conduit_id", ConduitId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("client_id"), ClientId)
+            .Set(new ConditionKey("conduit_id"), ConduitId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Drops/DropEntitlementGrant.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Drops/DropEntitlementGrant.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -20,8 +21,8 @@ public sealed record DropEntitlementGrant(OrganizationId OrganizationId, GameId?
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("organization_id", OrganizationId)
-            .Set("category_id", CategoryId)
-            .Set("campaign_id", CampaignId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("organization_id"), OrganizationId)
+            .Set(new ConditionKey("category_id"), CategoryId)
+            .Set(new ConditionKey("campaign_id"), CampaignId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Drops/DropEntitlementGrant.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Drops/DropEntitlementGrant.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -16,8 +16,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record DropEntitlementGrant(OrganizationId OrganizationId, GameId? CategoryId = null, DropsCampaignId? CampaignId = null)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.DROP_ENTITLEMENT_GRANT);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.DropEntitlementGrant;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Extension/ExtensionBitsTransactionCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Extension/ExtensionBitsTransactionCreate.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -18,6 +19,6 @@ public sealed record ExtensionBitsTransactionCreate(ClientId ExtensionClientId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("extension_client_id", ExtensionClientId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("extension_client_id"), ExtensionClientId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Extension/ExtensionBitsTransactionCreate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Extension/ExtensionBitsTransactionCreate.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -14,8 +14,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record ExtensionBitsTransactionCreate(ClientId ExtensionClientId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.EXTENSION_BITS_TRANSACTION_CREATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.ExtensionBitsTransactionCreate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOffline.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOffline.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record StreamOffline(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOffline.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOffline.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record StreamOffline(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.STREAM_OFFLINE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.StreamOffline;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOnline.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOnline.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -13,8 +13,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record StreamOnline(UserId BroadcasterUserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.STREAM_ONLINE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.StreamOnline;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOnline.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/Stream/StreamOnline.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -17,6 +18,6 @@ public sealed record StreamOnline(UserId BroadcasterUserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("broadcaster_user_id", BroadcasterUserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("broadcaster_user_id"), BroadcasterUserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationGrant.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationGrant.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -21,6 +22,6 @@ public sealed record UserAuthorizationGrant(ClientId ClientId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("client_id", ClientId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("client_id"), ClientId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationGrant.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationGrant.cs
@@ -1,24 +1,23 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user’s authorization has been granted to your client id.
+/// A user's authorization has been granted to your client id.
 /// </summary>
 /// <remarks>
 /// <b>Note:</b> This subscription type is only supported with the webhook transport. It cannot be used with WebSockets.
 /// Requires an app access token created by the same client id as the <paramref name="ClientId"/> parameter.
 /// </remarks>
 /// <param name="ClientId">
-/// The client id of the application to get authorization grant notifications for. 
-/// This must match the client id in the application access token used to make the request.
+/// The client id of the application to get authorization grant notifications for.
+/// This must match the client id in the application access token used to make the request.
 /// </param>
 public sealed record UserAuthorizationGrant(ClientId ClientId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.USER_AUTHORIZATION_GRANT);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.UserAuthorizationGrant;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationRevoke.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationRevoke.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -22,6 +23,6 @@ public sealed record UserAuthorizationRevoke(ClientId ClientId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("client_id", ClientId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("client_id"), ClientId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationRevoke.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Authorization/UserAuthorizationRevoke.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
-using TwitchySharp.Shared.EventSub.Constants;
+using System.Collections.Generic;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
-/// A user’s authorization has been revoked for your client id.
+/// A user's authorization has been revoked for your client id.
 /// Use this webhook to meet government requirements for handling user data, such as GDPR, LGPD, or CCPA.
 /// </summary>
 /// <remarks>
@@ -12,14 +12,13 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// Requires an app access token created by the same client id as the <paramref name="ClientId"/> parameter.
 /// </remarks>
 /// <param name="ClientId">
-/// The client id of the application to get authorization revocation notifications for. 
-/// This must match the client id in the application access token used to make the request.
+/// The client id of the application to get authorization revocation notifications for.
+/// This must match the client id in the application access token used to make the request.
 /// </param>
 public sealed record UserAuthorizationRevoke(ClientId ClientId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.USER_AUTHORIZATION_REVOKE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.UserAuthorizationRevoke;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/UserUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/UserUpdate.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -19,6 +20,6 @@ public sealed record UserUpdate(UserId UserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/UserUpdate.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/UserUpdate.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -8,15 +8,14 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// A user has updated their account.
 /// </summary>
 /// <remarks>
-/// No authorization required. 
+/// No authorization required.
 /// If the client id used to make the request has a user access token that includes <see cref="Scope.UserReadEmail"/>, the notification will include the email field.
 /// </remarks>
 /// <param name="UserId">The user id for the user you want update notifications for.</param>
 public sealed record UserUpdate(UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.USER_UPDATE);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.UserUpdate;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
@@ -13,9 +13,11 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// </remarks>
 /// <param name="UserId">The user id of the user receiving the whisper.</param>
 public sealed record WhisperReceived(UserId UserId)
-    : IEventSubSubscriptionType
+    : IUserAuthorizedSubscriptionType
 {
     public EventSubSubscriptionType Type => EventSubSubscriptionType.WhisperReceived;
+    public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+    public IEnumerable<Scope> ValidScopes => [ Scope.UserReadWhispers, Scope.UserManageWhispers ];
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
-using TwitchySharp.Shared.EventSub.Constants;
+using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
@@ -14,8 +14,7 @@ namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 public sealed record WhisperReceived(UserId UserId)
     : IEventSubSubscriptionType
 {
-    public EventSubSubscriptionTypeName Name { get; } = new(EventSubSubscriptionTypeNames.WHISPER_RECEIVED);
-    public EventSubSubscriptionTypeVersion Version { get; } = new(EventSubSubscriptionTypeVersions.V1);
+    public EventSubSubscriptionType Type => EventSubSubscriptionType.WhisperReceived;
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()

--- a/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/SubscriptionTypes/User/Whisper/WhisperReceived.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using TwitchySharp.Api.Authorization;
 using TwitchySharp.Shared.EventSub.Enums;
 using TwitchySharp.Shared.Models;
+using TwitchySharp.Shared.EventSub;
 
 namespace TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
 /// <summary>
@@ -18,6 +19,6 @@ public sealed record WhisperReceived(UserId UserId)
 
     private readonly EventSubSubscriptionCondition _condition =
         new EventSubSubscriptionCondition()
-            .Set("user_id", UserId);
-    public IReadOnlyDictionary<string, object> Condition => _condition;
+            .Set(new ConditionKey("user_id"), UserId);
+    public IReadOnlyDictionary<ConditionKey, object> Condition => _condition;
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/Transports/ConduitSubscriptionTransport.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/Transports/ConduitSubscriptionTransport.cs
@@ -7,7 +7,7 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// An EventSub transport that uses <see href="https://dev.twitch.tv/docs/eventsub/handling-conduit-events/">conduits</see>.
 /// </summary>
 public sealed record ConduitSubscriptionTransport
-    : NewEventSubSubscriptionTransport
+    : EventSubSubscriptionTransportSpecification
 {
     /// <param name="conduitId">The id of the conduit to use for the subscription notifications.</param>
     public ConduitSubscriptionTransport(ConduitId conduitId)

--- a/TwitchySharp.Api/Helix/EventSub/Models/Transports/EventSubSubscriptionTransportSpecification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/Transports/EventSubSubscriptionTransportSpecification.cs
@@ -10,7 +10,7 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// <remarks>
 /// See built-in derived types <see cref="WebhookSubscriptionTransport"/>, <see cref="WebsocketSubscriptionTransport"/>, and <see cref="ConduitSubscriptionTransport"/>.
 /// </remarks>
-public abstract record NewEventSubSubscriptionTransport
+public abstract record EventSubSubscriptionTransportSpecification
 {
     /// <summary>
     /// The transport method identifier.

--- a/TwitchySharp.Api/Helix/EventSub/Models/Transports/WebhookSubscriptionTransport.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/Transports/WebhookSubscriptionTransport.cs
@@ -7,7 +7,7 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// An EventSub transport that uses <see href="https://dev.twitch.tv/docs/eventsub/handling-webhook-events/">webhooks</see>.
 /// </summary>
 public sealed record WebhookSubscriptionTransport
-    : NewEventSubSubscriptionTransport
+    : EventSubSubscriptionTransportSpecification
 {
     /// <param name="callback">
     /// The url that subscription notifications will be sent to.

--- a/TwitchySharp.Api/Helix/EventSub/Models/Transports/WebsocketSubscriptionTransport.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/Transports/WebsocketSubscriptionTransport.cs
@@ -7,7 +7,7 @@ namespace TwitchySharp.Api.Helix.EventSub;
 /// An EventSub transport that uses <see href="https://dev.twitch.tv/docs/eventsub/handling-websocket-events/">WebSockets</see>.
 /// </summary>
 public sealed record WebsocketSubscriptionTransport
-    : NewEventSubSubscriptionTransport
+    : EventSubSubscriptionTransportSpecification
 {
     /// <param name="sessionId">
     /// The session id of the WebSocket connection to send notifications to.

--- a/TwitchySharp.Api/ITokenResolver.cs
+++ b/TwitchySharp.Api/ITokenResolver.cs
@@ -16,8 +16,8 @@ public interface ITokenResolver
 public class DefaultTokenResolver
     : ITokenResolver
 {
-    public ValueTask<AccessToken> GetToken(TwitchApiIdentity identity, IEnumerable<Scope> validScopes, CancellationToken ct = default)
+    public ValueTask<AccessToken> GetToken(ITwitchRequest request, CancellationToken ct = default)
     {
-        
+        throw new NotImplementedException();
     }
 }

--- a/TwitchySharp.Shared/EventSub/ConditionKey.cs
+++ b/TwitchySharp.Shared/EventSub/ConditionKey.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json.Serialization;
+using TwitchySharp.Helpers;
+
+namespace TwitchySharp.Shared.EventSub;
+
+/// <summary>
+/// Represents a specific EventSub Subscription condition key.
+/// </summary>
+/// <remarks>
+/// See <see cref="https://dev.twitch.tv/docs/eventsub/eventsub-reference/#conditions">Conditions</see> for more information.
+/// </remarks>
+/// <param name="Value">The string value of the key.</param>
+[JsonConverter(typeof(WrapperJsonConverter<ConditionKey, string>))]
+public readonly record struct ConditionKey(string Value) : IWrapValue<string>
+{
+    public static implicit operator string(ConditionKey key)
+        => key.Value;
+    public override string ToString()
+        => Value;
+}


### PR DESCRIPTION
## Summary

Comprehensive refactor of the EventSub API to improve type safety, automatic identity resolution, and cleaner API design.

- Refactor `IEventSubSubscriptionType` to use `EventSubSubscriptionType` enum (#27)
- Add `ConditionKey` type for type-safe condition dictionary keys (#28)
- Create `IUserAuthorizedSubscriptionType` interface for subscriptions requiring user auth (#29)
- Create `EventSubIdentityResolver` with reflection-based identity lookup (#30)
- Update `CreateEventSubSubscriptionRequest` with automatic identity/scope resolution (#31)
- Update `DeleteEventSubSubscriptionRequest` with subscription-based identity resolution (#32)
- Add `ForWebsocketSubscriptions()` method to `GetEventSubSubscriptionsRequest` (#33)
- Rename `NewEventSubSubscription` to `EventSubSubscriptionSpecification` (#34)

## Key Changes

### Automatic Identity Resolution
Requests now automatically determine the correct `TwitchApiIdentity` based on subscription type and transport method. WebSocket subscriptions with user-authorized types resolve the `UserIdentity` from the condition dictionary.

### Type-Safe Conditions
New `ConditionKey` type provides compile-time safety for condition dictionary keys instead of raw strings.

### Interface Hierarchy
```
IEventSubSubscriptionType (base - 17 app-only types)
└── IUserAuthorizedSubscriptionType (65 user-authorized types)
    - AuthorizingUserConditionKey
    - ValidScopes
```

### Files Changed
- 98 files changed
- +1086 / -687 lines

## Test plan
- [x] Build passes with 0 warnings, 0 errors
- [ ] Manual testing of EventSub subscription create/delete flows
- [ ] Verify identity resolution works correctly for WebSocket vs Webhook transports

🤖 Generated with [Claude Code](https://claude.ai/code)