### PR TITLE
Add unit tests for EventSub identity resolution

### DIFF
--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_CreateEventSubSubscriptionRequest.cs
@@ -1,0 +1,212 @@
+using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_CreateEventSubSubscriptionRequest
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+    private const string MOCK_SESSION_ID = "session_abc";
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        var userIdentity = Assert.IsType<UserIdentity>(identity);
+        Assert.Equal(new UserId(MOCK_USER_ID), userIdentity.UserId);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookUserAuthorizedType_ReturnsDefault()
+    {
+        // Arrange - Webhook transport with user authorized type should use app identity
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketAppOnlyType_ReturnsDefault()
+    {
+        // Arrange - App-only subscription type with websocket transport
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookAppOnlyType_ReturnsDefault()
+    {
+        // Arrange
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var identity = GetDefaultIdentity(request);
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedTypeMissingCondition_ThrowsInvalidOperationException()
+    {
+        // Arrange - User authorized type missing the authorizing user condition
+        var subscriptionType = new MockUserAuthorizedTypeWithMissingCondition();
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => GetDefaultIdentity(request));
+    }
+
+    [Fact]
+    public void ValidScopes_WithUserAuthorizedType_ReturnsTypeScopes()
+    {
+        // Arrange
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+        var transport = new WebsocketSubscriptionTransport(new EventSubWebsocketSessionId(MOCK_SESSION_ID));
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var scopes = request.ValidScopes;
+
+        // Assert
+        Assert.Contains(Scope.ModeratorReadFollowers, scopes);
+    }
+
+    [Fact]
+    public void ValidScopes_WithAppOnlyType_ReturnsEmpty()
+    {
+        // Arrange
+        var subscriptionType = new StreamOnline(new UserId(MOCK_BROADCASTER_ID));
+        var transport = new WebhookSubscriptionTransport(
+            callback: new Uri("https://example.com/webhook"),
+            secret: "test_secret_123"
+        );
+        var request = new CreateEventSubSubscriptionRequest
+        {
+            Subscription = new EventSubSubscriptionSpecification
+            {
+                Type = subscriptionType,
+                Transport = transport
+            }
+        };
+
+        // Act
+        var scopes = request.ValidScopes;
+
+        // Assert
+        Assert.Empty(scopes);
+    }
+
+    /// <summary>
+    /// Helper to access the protected DefaultIdentity property through the public interface.
+    /// </summary>
+    private static TwitchApiIdentity GetDefaultIdentity(CreateEventSubSubscriptionRequest request)
+    {
+        // The Identity property falls back to DefaultIdentity when not set
+        // We can test this by not setting Identity and checking what Identity resolves to
+        return request.Identity;
+    }
+
+    /// <summary>
+    /// A mock user-authorized subscription type that is missing the authorizing user condition.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithMissingCondition : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("moderator_user_id");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        // Condition is missing the moderator_user_id key
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            [new ConditionKey("broadcaster_user_id")] = new UserId(MOCK_BROADCASTER_ID)
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_DeleteEventSubSubscriptionRequest.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_DeleteEventSubSubscriptionRequest
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+    private const string MOCK_SUBSCRIPTION_ID = "sub_123";
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedSubscription_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow with websocket transport
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID,
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        var userIdentity = Assert.IsType<UserIdentity>(identity);
+        Assert.Equal(new UserId(MOCK_USER_ID), userIdentity.UserId);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebhookSubscription_ReturnsDefault()
+    {
+        // Arrange - Webhook transport should use app identity
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID,
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithConduitSubscription_ReturnsDefault()
+    {
+        // Arrange - Conduit transport should use app identity
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+            },
+            EventSubTransportMethod.Conduit
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithSubscriptionIdOnly_ReturnsDefault()
+    {
+        // Arrange - No subscription provided, only ID
+        var request = new DeleteEventSubSubscriptionRequest
+        {
+            SubscriptionId = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID)
+        };
+
+        // Act
+        var identity = request.Identity;
+
+        // Assert
+        Assert.Equal(TwitchApiIdentity.Default, identity);
+    }
+
+    [Fact]
+    public void DefaultIdentity_WithWebsocketUserAuthorizedMissingCondition_ThrowsInvalidOperationException()
+    {
+        // Arrange - User authorized type with websocket but missing the authorizing user condition
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+                // moderator_user_id is missing
+            },
+            EventSubTransportMethod.Websocket
+        );
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => request.Identity);
+    }
+
+    [Fact]
+    public void Constructor_WithSubscription_SetsSubscriptionId()
+    {
+        // Arrange
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_BROADCASTER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var request = new DeleteEventSubSubscriptionRequest(subscription);
+
+        // Assert
+        Assert.Equal(subscription.Id, request.SubscriptionId);
+    }
+
+    private static EventSubSubscription CreateSubscription(
+        EventSubSubscriptionType type,
+        Dictionary<string, string> condition,
+        EventSubTransportMethod transportMethod)
+    {
+        return new EventSubSubscription
+        {
+            Id = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID),
+            Status = EventSubSubscriptionStatus.Enabled,
+            Type = new EventSubSubscriptionTypeName(type.Type),
+            Version = new EventSubSubscriptionTypeVersion(type.Version),
+            Condition = condition.ToImmutableDictionary(
+                kvp => new ConditionKey(kvp.Key),
+                kvp => kvp.Value),
+            CreatedAt = DateTimeOffset.UtcNow,
+            Transport = new EventSubSubscriptionTransport
+            {
+                Method = transportMethod
+            },
+            Cost = 1
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_EventSubIdentityResolver.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_EventSubIdentityResolver.cs
@@ -1,0 +1,162 @@
+using System.Collections.Immutable;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_EventSubIdentityResolver
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_SUBSCRIPTION_ID = "sub_123";
+
+    [Fact]
+    public void GetAuthorizingUser_WithUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow uses moderator_user_id as the authorizing user key
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999",
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithAppOnlyType_ReturnsNull()
+    {
+        // Arrange - StreamOnline does not require user authorization
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.StreamOnline,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithMissingConditionKey_ReturnsNull()
+    {
+        // Arrange - ChannelFollow requires moderator_user_id but it's missing
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999"
+                // moderator_user_id is missing
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithWebhookTransportUserAuthorizedType_ReturnsUserIdentity()
+    {
+        // Arrange - Even with webhook transport, the authorizing user should be resolved
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelFollow,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = "999",
+                ["moderator_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Webhook
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithBroadcasterAuthorizedType_ReturnsCorrectUser()
+    {
+        // Arrange - ChannelSubscribe uses broadcaster_user_id as the authorizing user key
+        var subscription = CreateSubscription(
+            EventSubSubscriptionType.ChannelSubscribe,
+            new Dictionary<string, string>
+            {
+                ["broadcaster_user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithUnknownSubscriptionType_ReturnsNull()
+    {
+        // Arrange - Unknown/custom subscription type not in the dictionary
+        var subscription = CreateSubscription(
+            new EventSubSubscriptionType("unknown.type", "1"),
+            new Dictionary<string, string>
+            {
+                ["user_id"] = MOCK_USER_ID
+            },
+            EventSubTransportMethod.Websocket
+        );
+
+        // Act
+        var result = subscription.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    private static EventSubSubscription CreateSubscription(
+        EventSubSubscriptionType type,
+        Dictionary<string, string> condition,
+        EventSubTransportMethod transportMethod)
+    {
+        return new EventSubSubscription
+        {
+            Id = new EventSubSubscriptionId(MOCK_SUBSCRIPTION_ID),
+            Status = EventSubSubscriptionStatus.Enabled,
+            Type = new EventSubSubscriptionTypeName(type.Type),
+            Version = new EventSubSubscriptionTypeVersion(type.Version),
+            Condition = condition.ToImmutableDictionary(
+                kvp => new ConditionKey(kvp.Key),
+                kvp => kvp.Value),
+            CreatedAt = DateTimeOffset.UtcNow,
+            Transport = new EventSubSubscriptionTransport
+            {
+                Method = transportMethod
+            },
+            Cost = 1
+        };
+    }
+}

--- a/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_UserAuthorizedSubscriptionTypeExtensions.cs
+++ b/TwitchySharp.Api.Tests.Unit/Helix/EventSub/Test_UserAuthorizedSubscriptionTypeExtensions.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using TwitchySharp.Api.Authorization;
+using TwitchySharp.Api.Helix.EventSub;
+using TwitchySharp.Api.Helix.EventSub.SubscriptionTypes;
+using TwitchySharp.Shared.EventSub;
+using TwitchySharp.Shared.EventSub.Enums;
+using TwitchySharp.Shared.Models;
+
+namespace TwitchySharp.Api.Tests.Unit.Helix.EventSub;
+
+public class Test_UserAuthorizedSubscriptionTypeExtensions
+{
+    private const string MOCK_USER_ID = "12345";
+    private const string MOCK_BROADCASTER_ID = "99999";
+
+    [Fact]
+    public void GetAuthorizingUser_WithValidCondition_ReturnsUserIdentity()
+    {
+        // Arrange - ChannelFollow has moderator_user_id as the authorizing user
+        var subscriptionType = new ChannelFollow(
+            BroadcasterUserId: new UserId(MOCK_BROADCASTER_ID),
+            ModeratorUserId: new UserId(MOCK_USER_ID)
+        );
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithMissingConditionKey_ReturnsNull()
+    {
+        // Arrange - A mock type that claims to have a condition key that doesn't exist
+        var subscriptionType = new MockUserAuthorizedTypeWithMissingKey();
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithNonUserIdConditionValue_ReturnsNull()
+    {
+        // Arrange - A mock type where the condition value is not a UserId
+        var subscriptionType = new MockUserAuthorizedTypeWithWrongValueType();
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetAuthorizingUser_WithBroadcasterAuthorizedType_ReturnsCorrectUser()
+    {
+        // Arrange - ChannelSubscribe uses broadcaster_user_id as the authorizing user
+        var subscriptionType = new ChannelSubscribe(new UserId(MOCK_USER_ID));
+
+        // Act
+        var result = subscriptionType.GetAuthorizingUser();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(new UserId(MOCK_USER_ID), result.UserId);
+    }
+
+    /// <summary>
+    /// Mock type where the authorizing user condition key doesn't exist in the condition.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithMissingKey : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("nonexistent_key");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            [new ConditionKey("broadcaster_user_id")] = new UserId(MOCK_BROADCASTER_ID)
+        };
+    }
+
+    /// <summary>
+    /// Mock type where the condition value is not a UserId.
+    /// </summary>
+    private sealed record MockUserAuthorizedTypeWithWrongValueType : IUserAuthorizedSubscriptionType
+    {
+        public EventSubSubscriptionType Type => EventSubSubscriptionType.ChannelFollow;
+        public ConditionKey AuthorizingUserConditionKey => new ConditionKey("user_id");
+        public IEnumerable<Scope> ValidScopes => [Scope.ModeratorReadFollowers];
+
+        public IReadOnlyDictionary<ConditionKey, object> Condition => new Dictionary<ConditionKey, object>
+        {
+            // Value is a string, not a UserId
+            [new ConditionKey("user_id")] = "not_a_user_id_type"
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for `EventSubIdentityResolver.GetAuthorizingUser` extension method
- Adds unit tests for `CreateEventSubSubscriptionRequest` identity and scope resolution
- Adds unit tests for `DeleteEventSubSubscriptionRequest` identity resolution
- Adds unit tests for `IUserAuthorizedSubscriptionType.GetAuthorizingUser` extension method

## Test Coverage
- 23 new tests covering the EventSub identity resolution logic
- Tests verify correct behavior for user-authorized and app-only subscription types
- Tests verify correct handling of WebSocket, Webhook, and Conduit transports
- Tests verify exception handling for invalid/missing conditions

Refs #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)