### PR TITLE
Enforce immutable design pattern and clean up request types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,3 +358,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/TwitchySharp.Api/Authorization/Models/ExtensionJwtPayload.cs
+++ b/TwitchySharp.Api/Authorization/Models/ExtensionJwtPayload.cs
@@ -22,16 +22,16 @@ public record ExtensionJwtPayload(UserId UserId)
     /// </summary>
     [JsonConverter(typeof(UnixSecondsDateTimeOffsetConverter))]
     [JsonPropertyName("exp")]
-    public DateTimeOffset ExpiresAt { get; set; } = DateTimeOffset.UtcNow.AddMinutes(120);
+    public DateTimeOffset ExpiresAt { get; init; } = DateTimeOffset.UtcNow.AddMinutes(120);
     /// <summary>
     /// The user id of the owner of the extension.
     /// </summary>
-    public UserId UserId { get; set; } = new(UserId);
+    public UserId UserId { get; init; } = new(UserId);
     /// <summary>
     /// The JWT role. This should always be set to <c>"external"</c> for EBS generated tokens.
     /// </summary>
     public string Role { get; } = "external";
-    public string? ChannelId { get; set; }
+    public string? ChannelId { get; init; }
     [JsonPropertyName("pubsub_perms")]
     public ExtensionPubSubPermissions PubSubPermissions { get; } = new()
     {
@@ -61,6 +61,6 @@ public record ExtensionJwtPayload(UserId UserId)
 
 public record ExtensionPubSubPermissions
 {
-    public string[]? Listen { get; set; }
-    public string[]? Send { get; set; }
+    public string[]? Listen { get; init; }
+    public string[]? Send { get; init; }
 }

--- a/TwitchySharp.Api/Authorization/Models/OidcClaims.cs
+++ b/TwitchySharp.Api/Authorization/Models/OidcClaims.cs
@@ -13,11 +13,11 @@ public class OidcClaims
     /// <summary>
     /// Claims that will be included in the id token of the authorization response.
     /// </summary>
-    public HashSet<OidcClaim> IdToken { get; set; } = [];
+    public HashSet<OidcClaim> IdToken { get; init; } = [];
     /// <summary>
     /// Claims that will be included when getting a response from the <see href="https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/#getting-claims-information-from-an-access-token">UserInfo</see> endpoint.
     /// </summary>
-    public HashSet<OidcClaim> Userinfo { get; set; } = [];
+    public HashSet<OidcClaim> Userinfo { get; init; } = [];
 
     /// <summary>
     /// JSON encode the OIDC claims to be used in the claims query parameter of an authorization url.

--- a/TwitchySharp.Api/Helix/Ads/Endpoints/GetAdSchedule/GetAdScheduleRequest.cs
+++ b/TwitchySharp.Api/Helix/Ads/Endpoints/GetAdSchedule/GetAdScheduleRequest.cs
@@ -32,5 +32,5 @@ public record GetAdScheduleRequest
     /// <remarks>
     /// The request will be made on behalf of this user and requires <see cref="Scope.ChannelReadAds"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Ads/Endpoints/SnoozeNextAd/SnoozeNextAdRequest.cs
+++ b/TwitchySharp.Api/Helix/Ads/Endpoints/SnoozeNextAd/SnoozeNextAdRequest.cs
@@ -34,5 +34,5 @@ public record SnoozeNextAdRequest
     /// This must be the same user that provided the access token for the request.
     /// Requires <see cref="Scope.ChannelManageAds"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Ads/Endpoints/StartCommercial/StartCommercialRequest.cs
+++ b/TwitchySharp.Api/Helix/Ads/Endpoints/StartCommercial/StartCommercialRequest.cs
@@ -23,7 +23,7 @@ public record StartCommercialRequest
     protected override TwitchApiIdentity DefaultIdentity => new UserIdentity(Commercial.BroadcasterId);
     public override IEnumerable<Scope> ValidScopes => [ Scope.ChannelEditCommercial ];
     public override object? ContentObject => Commercial;
-    public required StartCommercialRequestData Commercial { get; set; }
+    public required StartCommercialRequestData Commercial { get; init; }
 }
 
 /// <summary>
@@ -38,7 +38,7 @@ public record StartCommercialRequestData
     /// This ID must match the user ID of the access token.
     /// Requires <see cref="Scope.ChannelEditCommercial"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The length of the commercial to run.
     /// </summary>
@@ -48,5 +48,5 @@ public record StartCommercialRequestData
     /// </remarks>
 
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public required TimeSpan Length { get; set; }
+    public required TimeSpan Length { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Analytics/Endpoints/GetExtensionAnalytics/GetExtensionAnalyticsRequest.cs
+++ b/TwitchySharp.Api/Helix/Analytics/Endpoints/GetExtensionAnalytics/GetExtensionAnalyticsRequest.cs
@@ -35,7 +35,7 @@ public record GetExtensionAnalyticsRequest
     /// <summary>
     /// The user to get extension analytics as.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The extension's client id.
@@ -44,12 +44,12 @@ public record GetExtensionAnalyticsRequest
     /// If specified, the response contains a report for the specified extension.
     /// If left <see langword="null"/>, the response includes a report for each extension that the authenticated user owns.
     /// </remarks>
-    public ExtensionId? ExtensionId { get; set; }
+    public ExtensionId? ExtensionId { get; init; }
 
     /// <summary>
     /// The type of analytics report to get.
     /// </summary>
-    public ExtensionAnalyticsReportType? Type { get; set; }
+    public ExtensionAnalyticsReportType? Type { get; init; }
 
     /// <summary>
     /// The reporting window's start date.
@@ -57,7 +57,7 @@ public record GetExtensionAnalyticsRequest
     /// <remarks>
     /// Use <see cref="WithinDateRange(DateTimeOffset, DateTimeOffset)"/> to set.
     /// </remarks>
-    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? StartedAt { get; private init; }
 
     /// <summary>
     /// The reporting window's end date.
@@ -65,7 +65,7 @@ public record GetExtensionAnalyticsRequest
     /// <remarks>
     /// Use <see cref="WithinDateRange(DateTimeOffset, DateTimeOffset)"/> to set.
     /// </remarks>
-    public DateTimeOffset? EndedAt { get; private set; }
+    public DateTimeOffset? EndedAt { get; private init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -73,7 +73,7 @@ public record GetExtensionAnalyticsRequest
     /// <remarks>
     /// While you may specify a maximum value of 100, the response will contain at most 20 URLs per page.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationCursor"/>
@@ -81,7 +81,7 @@ public record GetExtensionAnalyticsRequest
     /// <remarks>
     /// This parameter is ignored if <see cref="ExtensionId"/> is not <see langword="null"/>.
     /// </remarks>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// Sets the reporting window for the request (the <see cref="StartedAt"/> and <see cref="EndedAt"/> parameters).
@@ -97,11 +97,7 @@ public record GetExtensionAnalyticsRequest
     /// Because it can take up to two days for the data to be available, you must specify an end date that's earlier than today minus one to two days.
     /// If not, the API ignores your end date and uses an end date that is today minus one to two days.
     /// </param>
-    /// <returns>This request with the date range set.</returns>
+    /// <returns>A new request with the date range set.</returns>
     public GetExtensionAnalyticsRequest WithinDateRange(DateTimeOffset startedAt, DateTimeOffset endedAt)
-    {
-        StartedAt = startedAt;
-        EndedAt = endedAt;
-        return this;
-    }
+        => this with { StartedAt = startedAt, EndedAt = endedAt };
 }

--- a/TwitchySharp.Api/Helix/Analytics/Endpoints/GetGameAnalytics/GetGameAnalyticsRequest.cs
+++ b/TwitchySharp.Api/Helix/Analytics/Endpoints/GetGameAnalytics/GetGameAnalyticsRequest.cs
@@ -17,7 +17,7 @@ namespace TwitchySharp.Api.Helix.Analytics;
 /// See <see href="https://dev.twitch.tv/docs/api/reference/#get-game-analytics">Get Game Analytics</see> for more information.
 /// </remarks>
 public record GetGameAnalyticsRequest
-    : TwitchHelixRequest<GetGameAnalyticsResponse>
+    : TwitchHelixRequest<GetGameAnalyticsResponse>, IPageableRequest
 {
     protected override string Path => "/analytics/games";
     public override HttpMethod Method => HttpMethod.Get;
@@ -35,7 +35,7 @@ public record GetGameAnalyticsRequest
     /// <summary>
     /// The user to get game analytics as.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The game's client ID.
@@ -44,12 +44,12 @@ public record GetGameAnalyticsRequest
     /// If specified, the response contains a report for the specified game.
     /// If not specified, the response includes a report for each of the authenticated user's games.
     /// </remarks>
-    public GameId? GameId { get; set; }
+    public GameId? GameId { get; init; }
 
     /// <summary>
     /// The type of analytics report to get.
     /// </summary>
-    public GameAnalyticsReportType? Type { get; set; }
+    public GameAnalyticsReportType? Type { get; init; }
 
     /// <summary>
     /// The reporting window's start date.
@@ -57,7 +57,7 @@ public record GetGameAnalyticsRequest
     /// <remarks>
     /// Use <see cref="WithinDateRange(DateTimeOffset, DateTimeOffset)"/> to set.
     /// </remarks>
-    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? StartedAt { get; private init; }
 
     /// <summary>
     /// The reporting window's end date.
@@ -65,7 +65,7 @@ public record GetGameAnalyticsRequest
     /// <remarks>
     /// Use <see cref="WithinDateRange(DateTimeOffset, DateTimeOffset)"/> to set.
     /// </remarks>
-    public DateTimeOffset? EndedAt { get; private set; }
+    public DateTimeOffset? EndedAt { get; private init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -73,7 +73,7 @@ public record GetGameAnalyticsRequest
     /// <remarks>
     /// While you may specify a maximum value of 100, the response will contain at most 20 URLs per page.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationCursor"/>
@@ -81,7 +81,7 @@ public record GetGameAnalyticsRequest
     /// <remarks>
     /// This parameter is ignored if <see cref="GameId"/> is not <see langword="null"/>.
     /// </remarks>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// Sets the reporting window for the request (the <see cref="StartedAt"/> and <see cref="EndedAt"/> parameters).
@@ -97,11 +97,7 @@ public record GetGameAnalyticsRequest
     /// Because it can take up to two days for the data to be available, you must specify an end date that's earlier than today minus one to two days.
     /// If not, the API ignores your end date and uses an end date that is today minus one to two days.
     /// </param>
-    /// <returns>This request with the date range set.</returns>
+    /// <returns>A new request with the date range set.</returns>
     public GetGameAnalyticsRequest WithinDateRange(DateTimeOffset startedAt, DateTimeOffset endedAt)
-    {
-        StartedAt = startedAt;
-        EndedAt = endedAt;
-        return this;
-    }
+        => this with { StartedAt = startedAt, EndedAt = endedAt };
 }

--- a/TwitchySharp.Api/Helix/Authorization/Endpoints/GetAuthorizationByUser/GetAuthorizationByUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Authorization/Endpoints/GetAuthorizationByUser/GetAuthorizationByUserRequest.cs
@@ -19,8 +19,6 @@ public record GetAuthorizationByUserRequest
 {
     protected override string Path => "/authorization/users";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("user_id", UserIds.Select(x => x.Value));
@@ -31,5 +29,5 @@ public record GetAuthorizationByUserRequest
     /// <remarks>
     /// A maximum of 10 user ids can be specified.
     /// </remarks>
-    public required IEnumerable<UserId> UserIds { get; set; }
+    public required IEnumerable<UserId> UserIds { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Bits/Endpoints/GetBitsLeaderboard/GetBitsLeaderboardRequest.cs
+++ b/TwitchySharp.Api/Helix/Bits/Endpoints/GetBitsLeaderboard/GetBitsLeaderboardRequest.cs
@@ -31,7 +31,7 @@ public record GetBitsLeaderboardRequest
     /// <summary>
     /// The broadcaster to get the bits leaderboard for.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The number of results (leaderboard entries) to return.
@@ -39,12 +39,12 @@ public record GetBitsLeaderboardRequest
     /// <remarks>
     /// The minimum count is 1 and the maximum is 100. The default is 10.
     /// </remarks>
-    public int? Count { get; set; }
+    public int? Count { get; init; }
 
     /// <summary>
     /// The time period over which data is aggregated.
     /// </summary>
-    public LeaderboardPeriod? Period { get; set; }
+    public LeaderboardPeriod? Period { get; init; }
 
     /// <summary>
     /// The start date used for determining the aggregation period.
@@ -52,7 +52,7 @@ public record GetBitsLeaderboardRequest
     /// <remarks>
     /// The start date is ignored if <see cref="Period"/> is <see cref="LeaderboardPeriod.All"/> or <see langword="null"/>.
     /// </remarks>
-    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? StartedAt { get; init; }
 
     /// <summary>
     /// The id of a user that has cheered bits in the channel.
@@ -61,5 +61,5 @@ public record GetBitsLeaderboardRequest
     /// If <see cref="Count"/> is greater than <c>1</c>, the response may include users ranked above and below the specified user.
     /// To get the leaderboard's top leaders, set this to <see langword="null"/>.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Bits/Endpoints/GetCheermotes/GetCheermotesRequest.cs
+++ b/TwitchySharp.Api/Helix/Bits/Endpoints/GetCheermotes/GetCheermotesRequest.cs
@@ -20,8 +20,6 @@ public record GetCheermotesRequest
 {
     protected override string Path => "/bits/cheermotes";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -34,5 +32,5 @@ public record GetCheermotesRequest
     /// If <see langword="null"/>, the response contains only global Cheermotes.
     /// If the broadcaster uploaded Cheermotes, the <see cref="Cheermote.Type"/> in the response is set to <see cref="CheermoteType.ChannelCustom"/>.
     /// </remarks>
-    public UserId? BroadcasterId { get; set; }
+    public UserId? BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/CCLs/Endpoints/GetContentClassificationLabels/GetContentClassificationLabelsRequest.cs
+++ b/TwitchySharp.Api/Helix/CCLs/Endpoints/GetContentClassificationLabels/GetContentClassificationLabelsRequest.cs
@@ -19,8 +19,6 @@ public record GetContentClassificationLabelsRequest
 {
     protected override string Path => "/content_classification_labels";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("locale", Locale?.Value);
@@ -31,5 +29,5 @@ public record GetContentClassificationLabelsRequest
     /// <remarks>
     /// Defaults to <see cref="ContentClassificationLocale.EnglishUnitedStates"/> if left <see langword="null"/>.
     /// </remarks>
-    public ContentClassificationLocale? Locale { get; set; }
+    public ContentClassificationLocale? Locale { get; init; }
 }

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/CreateCustomRewards/CreateCustomRewardsRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/CreateCustomRewards/CreateCustomRewardsRequest.cs
@@ -37,12 +37,12 @@ public record CreateCustomRewardsRequest
     /// This must be the same user that created the access token for the request.
     /// Requires <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The reward to create.
     /// </summary>
-    public required CreateCustomRewardsRequestData Reward { get; set; }
+    public required CreateCustomRewardsRequestData Reward { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/DeleteCustomReward/DeleteCustomRewardRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/DeleteCustomReward/DeleteCustomRewardRequest.cs
@@ -36,10 +36,10 @@ public record DeleteCustomRewardRequest
     /// This must be the same user that created the access token for the request.
     /// Requires <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the custom reward to delete.
     /// </summary>
-    public required RewardId RewardId { get; set; }
+    public required RewardId RewardId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/GetCustomReward/GetCustomRewardRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/GetCustomReward/GetCustomRewardRequest.cs
@@ -36,7 +36,7 @@ public record GetCustomRewardRequest
     /// This should be the same user that created the access token for the request.
     /// Requires <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// A list of reward ids to filter the rewards by.
@@ -47,7 +47,7 @@ public record GetCustomRewardRequest
     /// The response contains only the ids that were found.
     /// If none of the ids were found, the response is 404 Not Found.
     /// </remarks>
-    public IEnumerable<RewardId>? RewardIds { get; set; }
+    public IEnumerable<RewardId>? RewardIds { get; init; }
 
     /// <summary>
     /// Determines whether the response contains only the custom rewards that the app may manage.
@@ -56,5 +56,5 @@ public record GetCustomRewardRequest
     /// Set to <see langword="true"/> to get only the custom rewards that the app may manage.
     /// The default is <see langword="false"/>.
     /// </remarks>
-    public bool? OnlyManageableRewards { get; set; }
+    public bool? OnlyManageableRewards { get; init; }
 }

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/GetCustomRewardRedemption/GetCustomRewardRedemptionRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/GetCustomRewardRedemption/GetCustomRewardRedemptionRequest.cs
@@ -40,7 +40,7 @@ public record GetCustomRewardRedemptionRequest
     /// This must also be the user that created the user access token for the request.
     /// Requires <see cref="Scope.ChannelReadRedemptions"/> or <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id that identifies the custom reward whose redemptions you want to get.
@@ -48,7 +48,7 @@ public record GetCustomRewardRedemptionRequest
     /// <remarks>
     /// At least one of <see cref="RewardId"/> or <see cref="Status"/> should be specified.
     /// </remarks>
-    public RewardId? RewardId { get; set; }
+    public RewardId? RewardId { get; init; }
 
     /// <summary>
     /// The status of the redemptions to return.
@@ -57,7 +57,7 @@ public record GetCustomRewardRedemptionRequest
     /// Canceled and fulfilled redemptions are returned for only a few days after they're canceled or fulfilled.
     /// At least one of <see cref="RewardId"/> or <see cref="Status"/> should be specified.
     /// </remarks>
-    public RewardRedemptionStatus? Status { get; set; }
+    public RewardRedemptionStatus? Status { get; init; }
 
     /// <summary>
     /// A list of redemption ids to filter the redemptions by.
@@ -68,7 +68,7 @@ public record GetCustomRewardRedemptionRequest
     /// The response contains only the ids that were found.
     /// If none of the ids were found, the response is 404 Not Found.
     /// </remarks>
-    public IEnumerable<RewardRedemptionId>? Ids { get; set; }
+    public IEnumerable<RewardRedemptionId>? Ids { get; init; }
 
     /// <summary>
     /// The order to sort redemptions by.
@@ -76,10 +76,10 @@ public record GetCustomRewardRedemptionRequest
     /// <remarks>
     /// The default is <see cref="CustomRewardRedemptionSortingMethod.Oldest"/>.
     /// </remarks>
-    public CustomRewardRedemptionSortingMethod? Sort { get; set; }
+    public CustomRewardRedemptionSortingMethod? Sort { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -87,5 +87,5 @@ public record GetCustomRewardRedemptionRequest
     /// <remarks>
     /// The minimum page size is 1 redemption per page and the maximum is 50.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 }

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/UpdateCustomReward/UpdateCustomRewardRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/UpdateCustomReward/UpdateCustomRewardRequest.cs
@@ -38,17 +38,17 @@ public record UpdateCustomRewardRequest
     /// This must be the same user that created the access token for the request.
     /// Requires <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the reward to update.
     /// </summary>
-    public required RewardId RewardId { get; set; }
+    public required RewardId RewardId { get; init; }
 
     /// <summary>
     /// The data that the reward should be updated to.
     /// </summary>
-    public required UpdateCustomRewardRequestData UpdatedReward { get; set; }
+    public required UpdateCustomRewardRequestData UpdatedReward { get; init; }
 }
 
 /// <summary>
@@ -60,73 +60,73 @@ public record UpdateCustomRewardRequestData
     /// The reward's title.
     /// The title may contain a maximum of 45 characters and it must be unique amongst all of the broadcaster's custom rewards.
     /// </summary>
-    public string? Title { get; set; }
+    public string? Title { get; init; }
     /// <summary>
     /// The prompt shown to the viewer when they redeem the reward.
     /// Specify a prompt if <see cref="IsUserInputRequired"/> is <see langword="true"/>.
     /// The prompt is limited to a maximum of 200 characters.
     /// </summary>
-    public string? Prompt { get; set; }
+    public string? Prompt { get; init; }
     /// <summary>
     /// The cost of the reward, in channel points. The minimum is 1 point.
     /// </summary>
-    public long? Cost { get; set; }
+    public long? Cost { get; init; }
     /// <summary>
     /// The background color to use for the reward.
     /// </summary>
-    public RgbColor? BackgroundColor { get; set; }
+    public RgbColor? BackgroundColor { get; init; }
     /// <summary>
     /// Determines whether the reward is enabled.
     /// Set to <see langword="true"/> to enable the reward. Viewers see only enabled rewards.
     /// </summary>
-    public bool? IsEnabled { get; set; }
+    public bool? IsEnabled { get; init; }
     /// <summary>
     /// Determines whether users must enter information to redeem the reward.
     /// Set to true if user input is required.
     /// The <see cref="Prompt"/> is shown to the user if set to <see langword="true"/>.
     /// </summary>
-    public bool? IsUserInputRequired { get; set; }
+    public bool? IsUserInputRequired { get; init; }
     /// <summary>
     /// Determines whether to limit the maximum number of redemptions allowed per live stream (amount specified with <see cref="MaxPerStream"/>).
     /// Set to <see langword="true"/> to limit redemptions.
     /// </summary>
-    public bool? IsMaxPerStreamEnabled { get; set; }
+    public bool? IsMaxPerStreamEnabled { get; init; }
     /// <summary>
     /// The maximum number of redemptions allowed per live stream.
     /// Applied only if <see cref="IsMaxPerStreamEnabled"/> is <see langword="true"/>. The minimum value is 1.
     /// </summary>
-    public long? MaxPerStream { get; set; }
+    public long? MaxPerStream { get; init; }
     /// <summary>
     /// Determines whether to limit the maximum number of redemptions allowed per user per stream (specified with <see cref="MaxPerUserPerStream"/>).
     /// The minimum value is 1. Set to <see langword="true"/> to limit redemptions.
     /// </summary>
-    public bool? IsMaxPerUserPerStreamEnabled { get; set; }
+    public bool? IsMaxPerUserPerStreamEnabled { get; init; }
     /// <summary>
     /// The maximum number of redemptions allowed per user per stream.
     /// Applied only if <see cref="IsMaxPerUserPerStreamEnabled"/> is <see langword="true"/>.
     /// </summary>
-    public long? MaxPerUserPerStream { get; set; }
+    public long? MaxPerUserPerStream { get; init; }
     /// <summary>
     /// Determines whether to apply a cooldown period between redemptions.
     /// Set to <see langword="true"/> to apply a cooldown period.
     /// The duration is specified by <see cref="GlobalCooldownSeconds"/>.
     /// </summary>
-    public bool? IsGlobalCooldownEnabled { get; set; }
+    public bool? IsGlobalCooldownEnabled { get; init; }
     /// <summary>
     /// The cooldown period.
     /// Applied only if <see cref="IsGlobalCooldownEnabled"/> is <see langword="true"/>.
     /// The minimum value is 1 second; however, for it to be shown in the Twitch UI, the minimum value is 60 seconds.
     /// </summary>
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public TimeSpan? GlobalCooldownSeconds { get; set; }
+    public TimeSpan? GlobalCooldownSeconds { get; init; }
     /// <summary>
     /// Determines whether to pause the reward.
     /// Set to <see langword="true"/> to pause the reward. Viewers can't redeem paused rewards.
     /// </summary>
-    public bool? IsPaused { get; set; }
+    public bool? IsPaused { get; init; }
     /// <summary>
     /// Determines whether redemptions should be set to FULFILLED status immediately when a reward is redeemed.
     /// If <see langword="false"/>, status is set to UNFULFILLED and follows the normal request queue process.
     /// </summary>
-    public bool? ShouldRedemptionsSkipRequestQueue { get; set; }
+    public bool? ShouldRedemptionsSkipRequestQueue { get; init; }
 }

--- a/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/UpdateRedemptionStatus/UpdateRedemptionStatusRequest.cs
+++ b/TwitchySharp.Api/Helix/ChannelPoints/Endpoints/UpdateRedemptionStatus/UpdateRedemptionStatusRequest.cs
@@ -39,12 +39,12 @@ public record UpdateRedemptionStatusRequest
     /// This must be the same user that created the access token for the request.
     /// Requires <see cref="Scope.ChannelManageRedemptions"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the custom reward to update redemptions on.
     /// </summary>
-    public required RewardId RewardId { get; set; }
+    public required RewardId RewardId { get; init; }
 
     /// <summary>
     /// A list of ids for the redemptions you want to update.
@@ -52,12 +52,12 @@ public record UpdateRedemptionStatusRequest
     /// <remarks>
     /// You may specify a maximum of 50 ids.
     /// </remarks>
-    public required IEnumerable<RewardRedemptionId> Ids { get; set; }
+    public required IEnumerable<RewardRedemptionId> Ids { get; init; }
 
     /// <summary>
     /// The status to set the redemptions to.
     /// </summary>
-    public required RewardRedemptionStatus Status { get; set; }
+    public required RewardRedemptionStatus Status { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/AddChannelVip/AddChannelVipRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/AddChannelVip/AddChannelVipRequest.cs
@@ -34,10 +34,10 @@ public record AddChannelVipRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ChannelManageVips"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the user to give VIP status to.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelEditors/GetChannelEditorsRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelEditors/GetChannelEditorsRequest.cs
@@ -31,5 +31,5 @@ public record GetChannelEditorsRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ChannelReadEditors"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelFollowers/GetChannelFollowersRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelFollowers/GetChannelFollowersRequest.cs
@@ -39,7 +39,7 @@ public record GetChannelFollowersRequest
     /// <remarks>
     /// Requires <see cref="Scope.ModeratorReadFollowers"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// Use this parameter to see whether a specific user follows this broadcaster.
@@ -48,7 +48,7 @@ public record GetChannelFollowersRequest
     /// If specified, the response contains this user if they follow the broadcaster.
     /// If not specified, the response contains all users that follow the broadcaster.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -56,8 +56,8 @@ public record GetChannelFollowersRequest
     /// <remarks>
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelInformation/GetChannelInformationRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/GetChannelInformation/GetChannelInformationRequest.cs
@@ -19,8 +19,6 @@ public record GetChannelInformationRequest
 {
     protected override string Path => "/channels";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterIds.Select(x => x.ToString()));
@@ -31,5 +29,5 @@ public record GetChannelInformationRequest
     /// <remarks>
     /// You may specify a maximum of 100 ids. The API ignores duplicate IDs and IDs that are not found.
     /// </remarks>
-    public required IEnumerable<UserId> BroadcasterIds { get; set; }
+    public required IEnumerable<UserId> BroadcasterIds { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/GetFollowedChannels/GetFollowedChannelsRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/GetFollowedChannels/GetFollowedChannelsRequest.cs
@@ -35,7 +35,7 @@ public record GetFollowedChannelsRequest
     /// This must be the user that created the access token used in the request.
     /// Requires <see cref="Scope.UserReadFollows"/>.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 
     /// <summary>
     /// Use this parameter to see whether the user follows a specific broadcaster.
@@ -44,7 +44,7 @@ public record GetFollowedChannelsRequest
     /// If specified, the response contains this broadcaster if the user follows them.
     /// If not specified, the response contains all broadcasters that the user follows.
     /// </remarks>
-    public UserId? BroadcasterId { get; set; }
+    public UserId? BroadcasterId { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -53,8 +53,8 @@ public record GetFollowedChannelsRequest
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/GetVips/GetVipsRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/GetVips/GetVipsRequest.cs
@@ -35,7 +35,7 @@ public record GetVipsRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ChannelReadVips"/> or <see cref="Scope.ChannelManageVips"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// Filter the list by specific users.
@@ -44,7 +44,7 @@ public record GetVipsRequest
     /// The maximum number of ids that you may specify is 100.
     /// Ignores the ids of users that aren't VIPs on the broadcaster's channel.
     /// </remarks>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -53,8 +53,8 @@ public record GetVipsRequest
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/ModifyChannelInformation/ModifyChannelInformationRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/ModifyChannelInformation/ModifyChannelInformationRequest.cs
@@ -34,12 +34,12 @@ public record ModifyChannelInformationRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The channel information to be set on the broadcaster's channel.
     /// </summary>
-    public required ModifyChannelInformationRequestData ChannelInformation { get; set; }
+    public required ModifyChannelInformationRequestData ChannelInformation { get; init; }
 }
 
 /// <summary>
@@ -52,19 +52,19 @@ public record ModifyChannelInformationRequestData
     /// The game is not updated if the ID isn’t a game ID that Twitch recognizes. 
     /// To unset this field, use <c>"0"</c> or <see cref="string.Empty"/>.
     /// </summary>
-    public GameId? GameId { get; set; }
+    public GameId? GameId { get; init; }
     /// <summary>
     /// The user’s preferred language. 
     /// Set the value to an ISO 639-1 two-letter language code (for example, en for English). 
     /// Set to "other" if the user’s preferred language is not a Twitch supported language. 
     /// The language isn’t updated if the language code isn’t a Twitch supported language.
     /// </summary>
-    public LanguageCode? BroadcasterLanguage { get; set; }
+    public LanguageCode? BroadcasterLanguage { get; init; }
     /// <summary>
     /// The title of the user’s stream. 
     /// You may not set this field to an empty string.
     /// </summary>
-    public string? Title { get; set; }
+    public string? Title { get; init; }
     /// <summary>
     /// The amount of time you want your broadcast buffered before streaming it live.
     /// The delay helps ensure fairness during competitive play. 
@@ -72,7 +72,7 @@ public record ModifyChannelInformationRequestData
     /// The maximum delay is 900 seconds (15 minutes).
     /// </summary>
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public TimeSpan? Delay { get; set; }
+    public TimeSpan? Delay { get; init; }
     /// <summary>
     /// A list of channel-defined tags to apply to the channel. 
     /// To remove all tags from the channel, set to an empty array.
@@ -83,13 +83,13 @@ public record ModifyChannelInformationRequestData
     /// Tags are case insensitive.
     /// For readability, consider using camelCasing or PascalCasing.
     /// </summary>
-    public string[]? Tags { get; set; }
+    public string[]? Tags { get; init; }
     /// <summary>
     /// List of labels that should be set as the Channel’s CCLs.
     /// </summary>
-    public ContentClassificationLabel[]? ContentClassificationLabels { get; set; }
+    public ContentClassificationLabel[]? ContentClassificationLabels { get; init; }
     /// <summary>
     /// Boolean flag indicating whether the branded content label should be enabled or disabled for the channel.
     /// </summary>
-    public bool? IsBrandedContent { get; set; }
+    public bool? IsBrandedContent { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Channels/Endpoints/RemoveChannelVip/RemoveChannelVipRequest.cs
+++ b/TwitchySharp.Api/Helix/Channels/Endpoints/RemoveChannelVip/RemoveChannelVipRequest.cs
@@ -35,7 +35,7 @@ public record RemoveChannelVipRequest
     /// If removing a user's VIP status on behalf of the broadcaster, the broadcaster must have created the access token used in the request.
     /// Requires <see cref="Scope.ChannelManageVips"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the user to revoke VIP status for.
@@ -43,5 +43,5 @@ public record RemoveChannelVipRequest
     /// <remarks>
     /// If removing this user's VIP status on behalf of the user themselves, this user can have created the access token used in the request.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Charity/Endpoints/GetCharityCampaign/GetCharityCampaignRequest.cs
+++ b/TwitchySharp.Api/Helix/Charity/Endpoints/GetCharityCampaign/GetCharityCampaignRequest.cs
@@ -33,5 +33,5 @@ public record GetCharityCampaignRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ChannelReadCharity"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Charity/Endpoints/GetCharityCampaignDonations/GetCharityCampaignDonationsRequest.cs
+++ b/TwitchySharp.Api/Helix/Charity/Endpoints/GetCharityCampaignDonations/GetCharityCampaignDonationsRequest.cs
@@ -33,7 +33,7 @@ public record GetCharityCampaignDonationsRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ChannelReadCharity"/>.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -42,8 +42,8 @@ public record GetCharityCampaignDonationsRequest
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetChannelChatBadges/GetChannelChatBadgesRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetChannelChatBadges/GetChannelChatBadgesRequest.cs
@@ -21,8 +21,6 @@ public record GetChannelChatBadgesRequest
 {
     protected override string Path => "/chat/badges";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -30,5 +28,5 @@ public record GetChannelChatBadgesRequest
     /// <summary>
     /// The user id of the broadcaster (channel) whose chat badges you want to get.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetChannelEmotes/GetChannelEmotesRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetChannelEmotes/GetChannelEmotesRequest.cs
@@ -22,8 +22,6 @@ public record GetChannelEmotesRequest
 {
     protected override string Path => "/chat/emotes";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -31,5 +29,5 @@ public record GetChannelEmotesRequest
     /// <summary>
     /// The user id of the broadcaster (channel) whose emotes you want to get.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetChatSettings/GetChatSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetChatSettings/GetChatSettingsRequest.cs
@@ -20,8 +20,6 @@ public record GetChatSettingsRequest
 {
     protected override string Path => "/chat/settings";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId)
@@ -30,7 +28,7 @@ public record GetChatSettingsRequest
     /// <summary>
     /// The user id of the broadcaster whose chat settings you want to get.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or one of the broadcaster's moderators.
@@ -39,5 +37,5 @@ public record GetChatSettingsRequest
     /// This parameter is only required if you want to include the <see cref="ChatSettings.NonModeratorChatDelay"/> and <see cref="ChatSettings.NonModeratorChatDelayDuration"/> in the response.
     /// If specified, this must be the same user that created the access token used in the request.
     /// </remarks>
-    public UserId? ModeratorId { get; set; }
+    public UserId? ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetChatters/GetChattersRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetChatters/GetChattersRequest.cs
@@ -39,7 +39,7 @@ public record GetChattersRequest
     /// <summary>
     /// The user id of the broadcaster whose chatters you want to get.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster OR one of the broadcaster's moderators.
@@ -48,7 +48,7 @@ public record GetChattersRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ModeratorReadChatters"/>.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -57,8 +57,8 @@ public record GetChattersRequest
     /// The minimum page size is 1 item per page and the maximum is 1,000.
     /// The default is 100.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetEmoteSets/GetEmoteSetsRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetEmoteSets/GetEmoteSetsRequest.cs
@@ -22,8 +22,6 @@ public record GetEmoteSetsRequest
 {
     protected override string Path => "/chat/emotes/set";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("emote_set_id", EmoteSetIds.Select(x => x.ToString()));
@@ -35,5 +33,5 @@ public record GetEmoteSetsRequest
     /// You may specify a maximum of 25 IDs.
     /// The response contains only the IDs that were found and ignores duplicate IDs.
     /// </remarks>
-    public required IEnumerable<EmoteSetId> EmoteSetIds { get; set; }
+    public required IEnumerable<EmoteSetId> EmoteSetIds { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetGlobalChatBadges/GetGlobalChatBadgesRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetGlobalChatBadges/GetGlobalChatBadgesRequest.cs
@@ -19,6 +19,4 @@ public record GetGlobalChatBadgesRequest
 {
     protected override string Path => "/chat/badges/global";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetGlobalEmotes/GetGlobalEmotesRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetGlobalEmotes/GetGlobalEmotesRequest.cs
@@ -19,6 +19,4 @@ public record GetGlobalEmotesRequest
 {
     protected override string Path => "/chat/emotes/global";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetSharedChatSession/GetSharedChatSessionRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetSharedChatSession/GetSharedChatSessionRequest.cs
@@ -18,8 +18,6 @@ public record GetSharedChatSessionRequest
 {
     protected override string Path => "/shared_chat/session";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -27,5 +25,5 @@ public record GetSharedChatSessionRequest
     /// <summary>
     /// The user id of the broadcaster whose shared chat you want to get.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetUserChatColor/GetUserChatColorRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetUserChatColor/GetUserChatColorRequest.cs
@@ -19,8 +19,6 @@ public record GetUserChatColorRequest
 {
     protected override string Path => "/chat/color";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("user_id", UserIds.Select(x => x.ToString()));
@@ -32,5 +30,5 @@ public record GetUserChatColorRequest
     /// The maximum number of ids that you may specify is 100.
     /// The API ignores duplicate ids and ids that weren't found.
     /// </remarks>
-    public required IEnumerable<UserId> UserIds { get; set; }
+    public required IEnumerable<UserId> UserIds { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/GetUserEmotes/GetUserEmotesRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/GetUserEmotes/GetUserEmotesRequest.cs
@@ -14,7 +14,7 @@ namespace TwitchySharp.Api.Helix.Chat;
 /// See <see href="https://dev.twitch.tv/docs/api/reference/#get-user-emotes">Get User Emotes</see> for more information.
 /// </remarks>
 public record GetUserEmotesRequest
-    : TwitchHelixRequest<GetUserEmotesResponse>
+    : TwitchHelixRequest<GetUserEmotesResponse>, IPageableRequest
 {
     protected override string Path => "/chat/emotes/user";
     public override HttpMethod Method => HttpMethod.Get;
@@ -33,7 +33,7 @@ public record GetUserEmotesRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.UserReadEmotes"/>.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 
     /// <summary>
     /// The user id of a broadcaster you wish to get follower emotes of.
@@ -42,8 +42,13 @@ public record GetUserEmotesRequest
     /// Using this query parameter will guarantee inclusion of the broadcaster's follower emotes in the response body.
     /// <b>Note:</b> If the user specified in <see cref="UserId"/> is subscribed to the broadcaster specified, their follower emotes will appear in the response body regardless if this query parameter is used.
     /// </remarks>
-    public UserId? BroadcasterId { get; set; }
+    public UserId? BroadcasterId { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
+
+    /// <summary>
+    /// Not supported by this endpoint. Present only to satisfy <see cref="IPageableRequest"/>.
+    /// </summary>
+    public PaginationAmount? First { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/SendChatAnnouncement/SendChatAnnouncementRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/SendChatAnnouncement/SendChatAnnouncementRequest.cs
@@ -29,7 +29,7 @@ public record SendChatAnnouncementRequest
     /// <summary>
     /// The user id of the broadcaster (channel) whose chat room you want to send the announcement to.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,12 +38,12 @@ public record SendChatAnnouncementRequest
     /// This must be the same user who created the access token used in the request.
     /// Requires <see cref="Scope.ModeratorManageAnnouncements"/>.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The announcement to send.
     /// </summary>
-    public required SendChatAnnouncementRequestData Announcement { get; set; }
+    public required SendChatAnnouncementRequestData Announcement { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/SendChatMessage/SendChatMessageRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/SendChatMessage/SendChatMessageRequest.cs
@@ -43,7 +43,7 @@ public record SendChatMessageRequest
     /// <summary>
     /// The message to send.
     /// </summary>
-    public required SendChatMessageRequestData Message { get; set; }
+    public required SendChatMessageRequestData Message { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/SendShoutout/SendShoutoutRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/SendShoutout/SendShoutoutRequest.cs
@@ -31,12 +31,12 @@ public record SendShoutoutRequest
     /// <summary>
     /// The user id of the broadcaster that's sending the shoutout.
     /// </summary>
-    public required UserId FromBroadcasterId { get; set; }
+    public required UserId FromBroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster that's receiving the shoutout.
     /// </summary>
-    public required UserId ToBroadcasterId { get; set; }
+    public required UserId ToBroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the moderator (or the broadcaster) to send the shoutout on behalf of.
@@ -45,5 +45,5 @@ public record SendShoutoutRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ModeratorManageShoutouts"/>.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/UpdateChatSettings/UpdateChatSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/UpdateChatSettings/UpdateChatSettingsRequest.cs
@@ -32,7 +32,7 @@ public record UpdateChatSettingsRequest
     /// <summary>
     /// The user id of the broadcaster whose chat settings you want to update.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -41,12 +41,12 @@ public record UpdateChatSettingsRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.ModeratorManageChatSettings"/>.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The settings that you want to change.
     /// </summary>
-    public required UpdateChatSettingsRequestData NewSettings { get; set; }
+    public required UpdateChatSettingsRequestData NewSettings { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Chat/Endpoints/UpdateUserChatColor/UpdateUserChatColorRequest.cs
+++ b/TwitchySharp.Api/Helix/Chat/Endpoints/UpdateUserChatColor/UpdateUserChatColorRequest.cs
@@ -32,10 +32,10 @@ public record UpdateUserChatColorRequest
     /// This must be the same user that created the access token used in the request.
     /// Requires <see cref="Scope.UserManageChatColor"/>.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 
     /// <summary>
     /// The color to use for the user's name in chat.
     /// </summary>
-    public required ChatColor Color { get; set; }
+    public required ChatColor Color { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Clips/Endpoints/CreateClip/CreateClipRequest.cs
+++ b/TwitchySharp.Api/Helix/Clips/Endpoints/CreateClip/CreateClipRequest.cs
@@ -51,17 +51,17 @@ public record CreateClipRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster (channel) to create a clip for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The title of the clip to create.
     /// </summary>
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
     /// <summary>
     /// The length of the clip to create.
@@ -70,5 +70,5 @@ public record CreateClipRequest
     /// Can range from 5 to 60 seconds, with a resolution of 100ms.
     /// Defaults to 30 seconds if left <see langword="null"/>.
     /// </remarks>
-    public TimeSpan? Duration { get; set; }
+    public TimeSpan? Duration { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Clips/Endpoints/GetClips/GetClipsRequest.cs
+++ b/TwitchySharp.Api/Helix/Clips/Endpoints/GetClips/GetClipsRequest.cs
@@ -22,8 +22,6 @@ public record GetClipsRequest
 {
     protected override string Path => "/clips";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", Query.Ids?.Select(x => x.ToString()))
@@ -42,7 +40,7 @@ public record GetClipsRequest
     /// <remarks>
     /// Use <see cref="BroadcasterClipsQuery"/>, <see cref="GameClipsQuery"/>, or <see cref="ClipsIdQuery"/>.
     /// </remarks>
-    public required ClipsQuery Query { get; set; }
+    public required ClipsQuery Query { get; init; }
 
     /// <summary>
     /// The start date used to filter clips.
@@ -50,7 +48,7 @@ public record GetClipsRequest
     /// <remarks>
     /// The API returns only clips within the start and end date window.
     /// </remarks>
-    public DateTimeOffset? StartedAt { get; set; }
+    public DateTimeOffset? StartedAt { get; init; }
 
     /// <summary>
     /// The end date used to filter clips.
@@ -58,7 +56,7 @@ public record GetClipsRequest
     /// <remarks>
     /// If <see langword="null"/>, the time window is <see cref="StartedAt"/> plus one week.
     /// </remarks>
-    public DateTimeOffset? EndedAt { get; set; }
+    public DateTimeOffset? EndedAt { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -67,15 +65,15 @@ public record GetClipsRequest
     /// The minimum page size is 1 clip per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 
     /// <summary>
     /// Determines whether the response includes featured clips.
@@ -85,7 +83,7 @@ public record GetClipsRequest
     /// If <see langword="false"/>, returns only clips that aren't featured.
     /// All clips are returned if this parameter is <see langword="null"/>.
     /// </remarks>
-    public bool? IsFeatured { get; set; }
+    public bool? IsFeatured { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Clips/Endpoints/GetClipsDownload/GetClipsDownloadRequest.cs
+++ b/TwitchySharp.Api/Helix/Clips/Endpoints/GetClipsDownload/GetClipsDownloadRequest.cs
@@ -36,12 +36,12 @@ public record GetClipsDownloadRequest
     /// This must be the user that created the access token used in the request.
     /// Requires <see cref="Scope.EditorManageClips"/> or <see cref="Scope.ChannelManageClips"/>.
     /// </remarks>
-    public required UserId EditorId { get; set; }
+    public required UserId EditorId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster (channel) to get clip downloads for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id(s) of the clips to get downloads for.
@@ -49,5 +49,5 @@ public record GetClipsDownloadRequest
     /// <remarks>
     /// A maximum of 10 clips can be requested at once.
     /// </remarks>
-    public required IEnumerable<ClipId> ClipIds { get; set; }
+    public required IEnumerable<ClipId> ClipIds { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/CreateConduit/CreateConduitRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/CreateConduit/CreateConduitRequest.cs
@@ -17,14 +17,12 @@ public record CreateConduitRequest
 {
     protected override string Path => "/eventsub/conduits";
     public override HttpMethod Method => HttpMethod.Post;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     public override object? ContentObject => ConduitData;
 
     /// <summary>
     /// Data used to construct the conduit.
     /// </summary>
-    public required CreateConduitRequestData ConduitData { get; set; }
+    public required CreateConduitRequestData ConduitData { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/DeleteConduit/DeleteConduitRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/DeleteConduit/DeleteConduitRequest.cs
@@ -20,8 +20,6 @@ public record DeleteConduitRequest
 {
     protected override string Path => "/eventsub/conduits";
     public override HttpMethod Method => HttpMethod.Delete;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", ConduitId);
@@ -29,5 +27,5 @@ public record DeleteConduitRequest
     /// <summary>
     /// The id of the conduit you want to delete.
     /// </summary>
-    public required ConduitId ConduitId { get; set; }
+    public required ConduitId ConduitId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/GetConduitShards/GetConduitShardsRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/GetConduitShards/GetConduitShardsRequest.cs
@@ -19,8 +19,6 @@ public record GetConduitShardsRequest
 {
     protected override string Path => "/eventsub/conduits/shards";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("conduit_id", ConduitId)
@@ -30,18 +28,18 @@ public record GetConduitShardsRequest
     /// <summary>
     /// The conduit id of the conduit you want to get shards for.
     /// </summary>
-    public required ConduitId ConduitId { get; set; }
+    public required ConduitId ConduitId { get; init; }
 
     /// <summary>
     /// Status to filter returned shards by.
     /// </summary>
-    public ConduitShardStatus? Status { get; set; }
+    public ConduitShardStatus? Status { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// Unused for this request type.
     /// </summary>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/GetConduits/GetConduitsRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/GetConduits/GetConduitsRequest.cs
@@ -16,6 +16,4 @@ public record GetConduitsRequest
 {
     protected override string Path => "/eventsub/conduits";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduit/UpdateConduitRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduit/UpdateConduitRequest.cs
@@ -21,14 +21,12 @@ public record UpdateConduitRequest
 {
     protected override string Path => "/eventsub/conduits";
     public override HttpMethod Method => HttpMethod.Patch;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     public override object? ContentObject => ConduitData;
 
     /// <summary>
     /// Data used to update the conduit.
     /// </summary>
-    public required UpdateConduitRequestData ConduitData { get; set; }
+    public required UpdateConduitRequestData ConduitData { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitShardUpdate.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitShardUpdate.cs
@@ -15,5 +15,5 @@ public record ConduitShardUpdate
     /// The transport details that you want to update the shard to.
     /// Use derived classes <see cref="ConduitWebsocketTransportUpdate"/> and <see cref="ConduitWebhookTransportUpdate"/>.
     /// </summary>
-    public required ConduitTransportUpdate Transport { get; set; }
+    public required ConduitTransportUpdate Transport { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitTransportUpdate.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitTransportUpdate.cs
@@ -13,21 +13,21 @@ public abstract record ConduitTransportUpdate
     /// <summary>
     /// The method to use for the transport.
     /// </summary>
-    public ConduitTransportMethod? Method { get; protected set; }
+    public ConduitTransportMethod? Method { get; protected init; }
     /// <summary>
     /// The callback url where webhook notifications are sent.
     /// The URL must use the HTTPS protocol and port 443.
     /// <b>Note:</b> Redirects are not followed.
     /// </summary>
-    public Uri? Callback { get; protected set; }
+    public Uri? Callback { get; protected init; }
     /// <summary>
     /// The secret used to verify the signature of a webhook notification.
     /// The secret must be an ASCII string that’s a minimum of 10 characters long and a maximum of 100 characters long.
     /// </summary>
-    public string? Secret { get; protected set; }
+    public string? Secret { get; protected init; }
     /// <summary>
     /// The id of the WebSocket connection to send notifications to.
     /// When you connect to EventSub using WebSockets, the server returns this id in the Welcome message.
     /// </summary>
-    public EventSubWebsocketSessionId? SessionId { get; protected set; }
+    public EventSubWebsocketSessionId? SessionId { get; protected init; }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitWebhookTransportUpdate.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitWebhookTransportUpdate.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using TwitchySharp.Shared.Enums;
 
 namespace TwitchySharp.Api.Helix.Conduits;
@@ -21,7 +21,7 @@ public record ConduitWebhookTransportUpdate
     public new Uri? Callback
     {
         get => base.Callback;
-        set => base.Callback = value;
+        init => base.Callback = value;
     }
 
     /// <summary>
@@ -30,6 +30,6 @@ public record ConduitWebhookTransportUpdate
     public new string? Secret
     {
         get => base.Secret;
-        set => base.Secret = value;
+        init => base.Secret = value;
     }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitWebsocketTransportUpdate.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/Models/ConduitWebsocketTransportUpdate.cs
@@ -1,4 +1,4 @@
-﻿using TwitchySharp.Shared.Enums;
+using TwitchySharp.Shared.Enums;
 using TwitchySharp.Shared.Models;
 
 namespace TwitchySharp.Api.Helix.Conduits;
@@ -21,6 +21,6 @@ public record ConduitWebsocketTransportUpdate
     public new EventSubWebsocketSessionId? SessionId
     {
         get => base.SessionId;
-        set => base.SessionId = value;
+        init => base.SessionId = value;
     }
 }

--- a/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/UpdateConduitShardsRequest.cs
+++ b/TwitchySharp.Api/Helix/Conduits/Endpoints/UpdateConduitShards/UpdateConduitShardsRequest.cs
@@ -17,14 +17,12 @@ public record UpdateConduitShardsRequest
 {
     protected override string Path => "/eventsub/conduits/shards";
     public override HttpMethod Method => HttpMethod.Patch;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     public override object? ContentObject => ShardUpdates;
 
     /// <summary>
     /// Data used to update the shards.
     /// </summary>
-    public required UpdateConduitShardsRequestData ShardUpdates { get; set; }
+    public required UpdateConduitShardsRequestData ShardUpdates { get; init; }
 }
 
 /// <summary>
@@ -35,9 +33,9 @@ public record UpdateConduitShardsRequestData
     /// <summary>
     /// The id of the conduit to update shards on.
     /// </summary>
-    public required ConduitId ConduitId { get; set; }
+    public required ConduitId ConduitId { get; init; }
     /// <summary>
     /// The shards to update.
     /// </summary>
-    public required ConduitShardUpdate[] Shards { get; set; }
+    public required ConduitShardUpdate[] Shards { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Entitlements/Endpoints/GetDropsEntitlements/GetDropsEntitlementsRequest.cs
+++ b/TwitchySharp.Api/Helix/Entitlements/Endpoints/GetDropsEntitlements/GetDropsEntitlementsRequest.cs
@@ -26,8 +26,6 @@ public record GetDropsEntitlementsRequest
 {
     protected override string Path => "/entitlements/drops";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", Ids?.Select(x => x.ToString()))
@@ -40,7 +38,7 @@ public record GetDropsEntitlementsRequest
     /// <summary>
     /// The ids of the specific entitlements to get.
     /// </summary>
-    public IEnumerable<DropsEntitlementId>? Ids { get; set; }
+    public IEnumerable<DropsEntitlementId>? Ids { get; init; }
 
     /// <summary>
     /// The user id to get entitlements for.
@@ -50,7 +48,7 @@ public record GetDropsEntitlementsRequest
     /// You can combine this parameter with <see cref="GameId"/>.
     /// Requires the use of an app access token for the request.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
 
     /// <summary>
     /// The game id to get entitlements for.
@@ -59,12 +57,12 @@ public record GetDropsEntitlementsRequest
     /// Use this parameter to get all entitlements for a specific game.
     /// You can combine this parameter with <see cref="UserId"/> if using an app access token.
     /// </remarks>
-    public GameId? GameId { get; set; }
+    public GameId? GameId { get; init; }
 
     /// <summary>
     /// Filters the returned entitlements by a specified fulfillment status.
     /// </summary>
-    public DropsEntitlementStatus? FulfillmentStatus { get; set; }
+    public DropsEntitlementStatus? FulfillmentStatus { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -73,8 +71,8 @@ public record GetDropsEntitlementsRequest
     /// The minimum page size is 1 entitlement per page and the maximum is 1000.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Entitlements/Endpoints/UpdateDropsEntitlements/UpdateDropsEntitlementsRequest.cs
+++ b/TwitchySharp.Api/Helix/Entitlements/Endpoints/UpdateDropsEntitlements/UpdateDropsEntitlementsRequest.cs
@@ -17,14 +17,12 @@ public record UpdateDropsEntitlementsRequest
 {
     protected override string Path => "/entitlements/drops";
     public override HttpMethod Method => HttpMethod.Patch;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     public override object? ContentObject => Updates;
 
     /// <summary>
     /// The updates to make to the entitlements.
     /// </summary>
-    public required UpdateDropsEntitlementsRequestData Updates { get; set; }
+    public required UpdateDropsEntitlementsRequestData Updates { get; init; }
 }
 
 /// <summary>
@@ -35,9 +33,9 @@ public record UpdateDropsEntitlementsRequestData
     /// <summary>
     /// The ids of the entitlements to update.
     /// </summary>
-    public IEnumerable<DropsEntitlementId>? EntitlementIds { get; set; }
+    public IEnumerable<DropsEntitlementId>? EntitlementIds { get; init; }
     /// <summary>
     /// The fulfillment status to update the entitlements to.
     /// </summary>
-    public DropsEntitlementStatus? FulfillmentStatus { get; set; }
+    public DropsEntitlementStatus? FulfillmentStatus { get; init; }
 }

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/CreateEventSubSubscription/CreateEventSubSubscriptionRequest.cs
@@ -54,7 +54,7 @@ public record CreateEventSubSubscriptionRequest
     /// <summary>
     /// The subscription to create.
     /// </summary>
-    public required EventSubSubscriptionSpecification Subscription { get; set; }
+    public required EventSubSubscriptionSpecification Subscription { get; init; }
 }
 
 internal record CreateEventSubSubscriptionRequestData

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/DeleteEventSubSubscription/DeleteEventSubSubscriptionRequest.cs
@@ -43,7 +43,6 @@ public record DeleteEventSubSubscriptionRequest()
         },
         _ => null
     } ?? TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", SubscriptionId);
@@ -81,5 +80,5 @@ public record DeleteEventSubSubscriptionRequest()
     /// <summary>
     /// The id of the subscription to delete.
     /// </summary>
-    public required EventSubSubscriptionId SubscriptionId { get; set; }
+    public required EventSubSubscriptionId SubscriptionId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/EventSub/Endpoints/GetEventSubSubscriptions/GetEventSubSubscriptionsRequest.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Endpoints/GetEventSubSubscriptions/GetEventSubSubscriptionsRequest.cs
@@ -24,8 +24,6 @@ public record GetEventSubSubscriptionsRequest
 {
     protected override string Path => "/eventsub/subscriptions";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("status", Status?.Value)
@@ -48,7 +46,7 @@ public record GetEventSubSubscriptionsRequest
     /// <summary>
     /// Specify this parameter to filter the returned list by subscription status.
     /// </summary>
-    public EventSubSubscriptionStatus? Status { get; set; }
+    public EventSubSubscriptionStatus? Status { get; init; }
 
     /// <summary>
     /// Specify this parameter to filter the returned list by subscription type.
@@ -56,7 +54,7 @@ public record GetEventSubSubscriptionsRequest
     /// <remarks>
     /// Note that this only filters by subscription type <b>name</b>, not version.
     /// </remarks>
-    public EventSubSubscriptionTypeName? Type { get; set; }
+    public EventSubSubscriptionTypeName? Type { get; init; }
 
     /// <summary>
     /// Specify this parameter to filter the returned list by a specific user.
@@ -64,7 +62,7 @@ public record GetEventSubSubscriptionsRequest
     /// <remarks>
     /// Only subscriptions that were created for this user are returned.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
 
     /// <summary>
     /// Specify this parameter to get a specific subscription by its id, as long as the subscription is owned by the client making the request.
@@ -72,13 +70,13 @@ public record GetEventSubSubscriptionsRequest
     /// <remarks>
     /// If a matching subscription does not exist, an empty array is returned.
     /// </remarks>
-    public EventSubSubscriptionId? SubscriptionId { get; set; }
+    public EventSubSubscriptionId? SubscriptionId { get; init; }
 
     /// <summary>
     /// Unused for this request type.
     /// </summary>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionSpecification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/EventSubSubscriptionSpecification.cs
@@ -8,12 +8,12 @@ public record EventSubSubscriptionSpecification
     /// The type of subscription to create.
     /// See the <see cref="EventSub.Types"/> namespace for built-in subscription types.
     /// </summary>
-    public required IEventSubSubscriptionType Type { get; set; }
+    public required IEventSubSubscriptionType Type { get; init; }
     /// <summary>
     /// The transport type that you want Twitch to use when sending you notifications.
     /// Possible transport types are <see cref="WebhookSubscriptionTransport"/>, <see cref="WebsocketSubscriptionTransport"/>, and <see cref="ConduitSubscriptionTransport"/>.
     /// </summary>
-    public required EventSubSubscriptionTransportSpecification Transport { get; set; }
+    public required EventSubSubscriptionTransportSpecification Transport { get; init; }
 }
 
 internal static class EventSubSubscriptionSpecificationExtensions

--- a/TwitchySharp.Api/Helix/EventSub/Models/Transports/EventSubSubscriptionTransportSpecification.cs
+++ b/TwitchySharp.Api/Helix/EventSub/Models/Transports/EventSubSubscriptionTransportSpecification.cs
@@ -15,24 +15,24 @@ public abstract record EventSubSubscriptionTransportSpecification
     /// <summary>
     /// The transport method identifier.
     /// </summary>
-    public EventSubTransportMethod Method { get; protected set; } = new(string.Empty);
+    public EventSubTransportMethod Method { get; protected init; } = new(string.Empty);
     /// <summary>
     /// The url that webhook subscription notifications will be sent to.
     /// </summary>
-    public Uri? Callback { get; protected set; }
+    public Uri? Callback { get; protected init; }
     /// <summary>
     /// The secret used to verify the signature of the webhook notification.
     /// </summary>
     /// <remarks>
     /// For information about how the secret is used, see <see href="https://dev.twitch.tv/docs/eventsub/handling-webhook-events#verifying-the-event-message">Verifying the event message</see>.
     /// </remarks>
-    public string? Secret { get; protected set; }
+    public string? Secret { get; protected init; }
     /// <summary>
     /// The id of the EventSub WebSocket session that notifications will be sent to.
     /// </summary>
-    public EventSubWebsocketSessionId? SessionId { get; protected set; }
+    public EventSubWebsocketSessionId? SessionId { get; protected init; }
     /// <summary>
     /// The id of the conduit that notifications are sent to.
     /// </summary>
-    public ConduitId? ConduitId { get; protected set; }
+    public ConduitId? ConduitId { get; protected init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/CreateExtensionSecret/CreateExtensionSecretRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/CreateExtensionSecret/CreateExtensionSecretRequest.cs
@@ -27,12 +27,11 @@ public record CreateExtensionSecretRequest
     protected override string Path => "/extensions/jwt/secrets";
     public override HttpMethod Method => HttpMethod.Post;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId)
@@ -41,7 +40,7 @@ public record CreateExtensionSecretRequest
     /// <summary>
     /// The id of the extension to apply the shared secret to.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// The amount of time to delay activating the secret.
@@ -51,5 +50,5 @@ public record CreateExtensionSecretRequest
     /// The minimum delay is 300 seconds (5 minutes).
     /// The default is 300 seconds.
     /// </remarks>
-    public TimeSpan? Delay { get; set; }
+    public TimeSpan? Delay { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionBitsProduct/GetExtensionBitsProductsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionBitsProduct/GetExtensionBitsProductsRequest.cs
@@ -20,8 +20,6 @@ public record GetExtensionBitsProductsRequest
 {
     protected override string Path => "/bits/extensions";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("should_include_all", ShouldIncludeAll?.ToString());
@@ -32,5 +30,5 @@ public record GetExtensionBitsProductsRequest
     /// <remarks>
     /// The default is <see langword="false"/>.
     /// </remarks>
-    public bool? ShouldIncludeAll { get; set; }
+    public bool? ShouldIncludeAll { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionConfigurationSegment/GetExtensionConfigurationSegmentRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionConfigurationSegment/GetExtensionConfigurationSegmentRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Http;
 using TwitchySharp.Api.Authorization;
@@ -22,17 +23,14 @@ namespace TwitchySharp.Api.Helix.Extensions;
 public record GetExtensionConfigurationSegmentRequest
     : TwitchHelixRequest<GetExtensionConfigurationSegmentResponse>
 {
-    private readonly HashSet<ExtensionConfigurationSegmentType> _segments = [];
-
     protected override string Path => "/extensions/configurations";
     public override HttpMethod Method => HttpMethod.Get;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId)
@@ -43,48 +41,45 @@ public record GetExtensionConfigurationSegmentRequest
     /// <inheritdoc cref="ExtensionConfigurationSegmentType.Broadcaster"/>
     /// </summary>
     /// <param name="broadcasterId"><inheritdoc cref="BroadcasterId" path="/summary"/></param>
-    /// <returns>This instance.</returns>
-    public GetExtensionConfigurationSegmentRequest AddBroadcaster(UserId broadcasterId)
-    {
-        _segments.Add(ExtensionConfigurationSegmentType.Broadcaster);
-        BroadcasterId = broadcasterId;
-        return this;
-    }
+    /// <returns>A new request with the broadcaster segment added.</returns>
+    public GetExtensionConfigurationSegmentRequest WithBroadcaster(UserId broadcasterId)
+        => this with
+        {
+            Segments = Segments.Add(ExtensionConfigurationSegmentType.Broadcaster),
+            BroadcasterId = broadcasterId
+        };
 
     /// <summary>
     /// <inheritdoc cref="ExtensionConfigurationSegmentType.Developer"/>
     /// </summary>
     /// <param name="broadcasterId"><inheritdoc cref="BroadcasterId" path="/summary"/></param>
-    /// <returns>This instance.</returns>
-    public GetExtensionConfigurationSegmentRequest AddDeveloper(UserId broadcasterId)
-    {
-        _segments.Add(ExtensionConfigurationSegmentType.Developer);
-        BroadcasterId = broadcasterId;
-        return this;
-    }
+    /// <returns>A new request with the developer segment added.</returns>
+    public GetExtensionConfigurationSegmentRequest WithDeveloper(UserId broadcasterId)
+        => this with
+        {
+            Segments = Segments.Add(ExtensionConfigurationSegmentType.Developer),
+            BroadcasterId = broadcasterId
+        };
 
     /// <summary>
     /// <inheritdoc cref="ExtensionConfigurationSegmentType.Global"/>
     /// </summary>
-    /// <returns>This instance.</returns>
-    public GetExtensionConfigurationSegmentRequest AddGlobal()
-    {
-        _segments.Add(ExtensionConfigurationSegmentType.Global);
-        return this;
-    }
+    /// <returns>A new request with the global segment added.</returns>
+    public GetExtensionConfigurationSegmentRequest WithGlobal()
+        => this with { Segments = Segments.Add(ExtensionConfigurationSegmentType.Global) };
 
     /// <summary>
     /// The extension id of the extension that contains the configuration segment you want to get.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// The type of configuration segment(s) to get.
     /// </summary>
     /// <remarks>
-    /// Use <see cref="AddGlobal"/>, <see cref="AddBroadcaster(UserId)"/>, and <see cref="AddDeveloper(UserId)"/> to configure.
+    /// Use <see cref="WithGlobal"/>, <see cref="WithBroadcaster(UserId)"/>, and <see cref="WithDeveloper(UserId)"/> to configure.
     /// </remarks>
-    public IEnumerable<ExtensionConfigurationSegmentType> Segments => _segments;
+    public ImmutableHashSet<ExtensionConfigurationSegmentType> Segments { get; private init; } = [];
 
     /// <summary>
     /// The user id of the broadcaster (channel) whose extension configuration you want to get.
@@ -92,5 +87,5 @@ public record GetExtensionConfigurationSegmentRequest
     /// <remarks>
     /// This parameter should be set if <see cref="Segments"/> includes <see cref="ExtensionConfigurationSegmentType.Broadcaster"/> or <see cref="ExtensionConfigurationSegmentType.Developer"/>.
     /// </remarks>
-    public UserId? BroadcasterId { get; private set; }
+    public UserId? BroadcasterId { get; private init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionLiveChannels/GetExtensionLiveChannelsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionLiveChannels/GetExtensionLiveChannelsRequest.cs
@@ -20,8 +20,6 @@ public record GetExtensionLiveChannelsRequest
 {
     protected override string Path => "/extensions/live";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId)
@@ -34,7 +32,7 @@ public record GetExtensionLiveChannelsRequest
     /// <remarks>
     /// The response will contain the list of broadcasters that are live and that have installed or activated this extension.
     /// </remarks>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -43,8 +41,8 @@ public record GetExtensionLiveChannelsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionSecrets/GetExtensionSecretsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionSecrets/GetExtensionSecretsRequest.cs
@@ -22,12 +22,11 @@ public record GetExtensionSecretsRequest
     protected override string Path => "/extensions/jwt/secrets";
     public override HttpMethod Method => HttpMethod.Get;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId);
@@ -35,5 +34,5 @@ public record GetExtensionSecretsRequest
     /// <summary>
     /// The id of the extension whose shared secrets you want to get.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionTransactions/GetExtensionTransactionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensionTransactions/GetExtensionTransactionsRequest.cs
@@ -21,8 +21,6 @@ public record GetExtensionTransactionsRequest
 {
     protected override string Path => "/extensions/transactions";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId)
@@ -33,7 +31,7 @@ public record GetExtensionTransactionsRequest
     /// <summary>
     /// The id of the extension whose list of transactions you want to get.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// The transaction ids used to filter the list of transactions.
@@ -41,7 +39,7 @@ public record GetExtensionTransactionsRequest
     /// <remarks>
     /// You may specify a maximum of 100 ids.
     /// </remarks>
-    public IEnumerable<ExtensionTransactionId>? TransactionIds { get; set; }
+    public IEnumerable<ExtensionTransactionId>? TransactionIds { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -50,8 +48,8 @@ public record GetExtensionTransactionsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensions/GetExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetExtensions/GetExtensionsRequest.cs
@@ -22,12 +22,11 @@ public record GetExtensionsRequest
     protected override string Path => "/extensions";
     public override HttpMethod Method => HttpMethod.Get;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId)
@@ -36,7 +35,7 @@ public record GetExtensionsRequest
     /// <summary>
     /// The id of the extension to get.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// The version of the extension to get.
@@ -45,5 +44,5 @@ public record GetExtensionsRequest
     /// If <see langword="null"/>, it returns the latest, released version.
     /// If the extension doesn't have a released version, you must specify a version; otherwise, <see cref="GetExtensionsResponse.Data"/> is empty.
     /// </remarks>
-    public ExtensionVersion? ExtensionVersion { get; set; }
+    public ExtensionVersion? ExtensionVersion { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/GetReleasedExtensions/GetReleasedExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/GetReleasedExtensions/GetReleasedExtensionsRequest.cs
@@ -20,8 +20,6 @@ public record GetReleasedExtensionsRequest
 {
     protected override string Path => "/extensions/released";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("extension_id", ExtensionId)
@@ -30,7 +28,7 @@ public record GetReleasedExtensionsRequest
     /// <summary>
     /// The id of the extension to get.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
 
     /// <summary>
     /// The version of the extension to get.
@@ -38,5 +36,5 @@ public record GetReleasedExtensionsRequest
     /// <remarks>
     /// If <see langword="null"/>, it returns the latest version.
     /// </remarks>
-    public ExtensionVersion? ExtensionVersion { get; set; }
+    public ExtensionVersion? ExtensionVersion { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/SendExtensionChatMessage/SendExtensionChatMessageRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/SendExtensionChatMessage/SendExtensionChatMessageRequest.cs
@@ -26,12 +26,11 @@ public record SendExtensionChatMessageRequest
     protected override string Path => "/extensions/chat";
     public override HttpMethod Method => HttpMethod.Post;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -40,12 +39,12 @@ public record SendExtensionChatMessageRequest
     /// <summary>
     /// The user id of the broadcaster with the extension to send a message to.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The message data to send.
     /// </summary>
-    public required SendExtensionChatMessageRequestData Message { get; set; }
+    public required SendExtensionChatMessageRequestData Message { get; init; }
 }
 
 /// <summary>
@@ -57,13 +56,13 @@ public record SendExtensionChatMessageRequestData
     /// The message to send in chat.
     /// The message may contain a maximum of 280 characters.
     /// </summary>
-    public required string Text { get; set; }
+    public required string Text { get; init; }
     /// <summary>
     /// The id of the extension that's sending the chat message.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
     /// <summary>
     /// The extension's version number.
     /// </summary>
-    public required ExtensionVersion ExtensionVersion { get; set; }
+    public required ExtensionVersion ExtensionVersion { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/SendExtensionPubSubMessage/SendExtensionPubSubMessageRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/SendExtensionPubSubMessage/SendExtensionPubSubMessageRequest.cs
@@ -27,19 +27,18 @@ public record SendExtensionPubSubMessageRequest
     protected override string Path => "/extensions/pubsub";
     public override HttpMethod Method => HttpMethod.Post;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     public override object? ContentObject => Message;
 
     /// <summary>
     /// Data used to create and send the message.
     /// Use derived classes <see cref="BroadcastPubSubMessageData"/> and <see cref="GlobalPubSubMessageData"/>.
     /// </summary>
-    public required SendExtensionPubSubMessageRequestData Message { get; set; }
+    public required SendExtensionPubSubMessageRequestData Message { get; init; }
 }
 
 /// <summary>
@@ -48,7 +47,7 @@ public record SendExtensionPubSubMessageRequest
 /// </summary>
 public record SendExtensionPubSubMessageRequestData
 {
-    protected ImmutableHashSet<ExtensionPubSubMessageTarget> _target { get; set; } = [];
+    protected ImmutableHashSet<ExtensionPubSubMessageTarget> _target { get; init; } = [];
     /// <summary>
     /// The target of the message. 
     /// The <see cref="ExtensionPubSubMessageTarget.Broadcast"/> and <see cref="ExtensionPubSubMessageTarget.Global"/> values are mutually exclusive.
@@ -58,17 +57,17 @@ public record SendExtensionPubSubMessageRequestData
     /// The user id of the broadcaster to send the message to. 
     /// Don’t include this field if <see cref="IsGlobalBroadcast"/> is set to <see langword="true"/>.
     /// </summary>
-    public UserId? BroadcasterId { get; protected set; }
+    public UserId? BroadcasterId { get; protected init; }
     /// <summary>
     /// Determines whether the message should be sent to all channels where your extension is active. 
     /// Set to <see langword="true"/> if the message should be sent to all channels. The default is <see langword="false"/>.
     /// </summary>
-    public bool? IsGlobalBroadcast { get; protected set; }
+    public bool? IsGlobalBroadcast { get; protected init; }
     /// <summary>
     /// The message to send. The message can be a plain-text string or a string-encoded JSON object. 
     /// The message is limited to a maximum of 5 KB.
     /// </summary>
-    public required string Message { get; set; }
+    public required string Message { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/SetExtensionConfigurationSegment/SetExtensionConfigurationSegmentRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/SetExtensionConfigurationSegment/SetExtensionConfigurationSegmentRequest.cs
@@ -26,12 +26,11 @@ public record SetExtensionConfigurationSegmentRequest
     protected override string Path => "/extensions/configurations";
     public override HttpMethod Method => HttpMethod.Put;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     public override object? ContentObject => Configuration;
 
     /// <summary>
@@ -40,7 +39,7 @@ public record SetExtensionConfigurationSegmentRequest
     /// <see cref="SetExtensionConfigurationDeveloperSegmentData"/>,
     /// <see cref="SetExtensionConfigurationBroadcasterSegmentData"/> for easier usage.
     /// </summary>
-    public required SetExtensionConfigurationSegmentRequestData Configuration { get; set; }
+    public required SetExtensionConfigurationSegmentRequestData Configuration { get; init; }
 }
 
 /// <summary>
@@ -57,26 +56,26 @@ public record SetExtensionConfigurationSegmentRequestData(ExtensionConfiguration
     /// <summary>
     /// The id of the extension to update.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
     /// <summary>
     /// The configuration segment to update.
     /// </summary>
-    public ExtensionConfigurationSegmentType Segment { get; set; } = Segment;
+    public ExtensionConfigurationSegmentType Segment { get; init; } = Segment;
     /// <summary>.
     /// The user id of the broadcaster that installed the extension.
     /// Include this property only if the <see cref="Segment"/> is set to <see cref="ExtensionConfigurationSegmentType.Developer"/> or <see cref="ExtensionConfigurationSegmentType.Broadcaster"/>.
     /// </summary>
-    public UserId? BroadcasterId { get; protected set; }
+    public UserId? BroadcasterId { get; protected init; }
     /// <summary>
     /// The contents of the segment.
     /// This may be in plain-text or string-encoded JSON.
     /// </summary>
-    public string? Content { get; set; }
+    public string? Content { get; init; }
     /// <summary>
     /// The version number that identifies this definition of the segment’s data. 
     /// If not specified, the latest definition is updated.
     /// </summary>
-    public ExtensionVersion? Version { get; set; }
+    public ExtensionVersion? Version { get; init; }
 }
 
 /// <summary>
@@ -94,7 +93,7 @@ public record SetExtensionConfigurationDeveloperSegmentData()
     /// <summary>
     /// The user id of the broadcaster to update extension configuration data for.
     /// </summary>
-    public new required UserId BroadcasterId { get => base.BroadcasterId!.Value; set => base.BroadcasterId = value; }
+    public new required UserId BroadcasterId { get => base.BroadcasterId!.Value; init => base.BroadcasterId = value; }
 }
 
 /// <summary>
@@ -106,5 +105,5 @@ public record SetExtensionConfigurationBroadcasterSegmentData()
     /// <summary>
     /// The user id of the broadcaster to update extension configuration data for.
     /// </summary>
-    public new required UserId BroadcasterId { get => base.BroadcasterId!.Value; set => base.BroadcasterId = value; }
+    public new required UserId BroadcasterId { get => base.BroadcasterId!.Value; init => base.BroadcasterId = value; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/SetExtensionRequiredConfiguration/SetExtensionRequiredConfigurationRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/SetExtensionRequiredConfiguration/SetExtensionRequiredConfigurationRequest.cs
@@ -25,12 +25,11 @@ public record SetExtensionRequiredConfigurationRequest
     protected override string Path => "/extensions/required_configuration";
     public override HttpMethod Method => HttpMethod.Put;
     protected override TwitchApiIdentity DefaultIdentity => ExtensionIdentity;
-    public override IEnumerable<Scope> ValidScopes => [];
 
     /// <summary>
     /// The extension identity used for JWT authentication.
     /// </summary>
-    public required ExtensionIdentity ExtensionIdentity { get; set; }
+    public required ExtensionIdentity ExtensionIdentity { get; init; }
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -39,12 +38,12 @@ public record SetExtensionRequiredConfigurationRequest
     /// <summary>
     /// The user id of the broadcaster with the extension to set required configuration for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The data used to set the required configuration setting.
     /// </summary>
-    public required SetExtensionRequiredConfigurationRequestData Configuration { get; set; }
+    public required SetExtensionRequiredConfigurationRequestData Configuration { get; init; }
 }
 
 /// <summary>
@@ -55,13 +54,13 @@ public record SetExtensionRequiredConfigurationRequestData
     /// <summary>
     /// The id of the extension to update.
     /// </summary>
-    public required ExtensionId ExtensionId { get; set; }
+    public required ExtensionId ExtensionId { get; init; }
     /// <summary>
     /// The version of the extension to update.
     /// </summary>
-    public required ExtensionVersion ExtensionVersion { get; set; }
+    public required ExtensionVersion ExtensionVersion { get; init; }
     /// <summary>
     /// The required_configuration string to use with the extension.
     /// </summary>
-    public required string RequiredConfiguration { get; set; }
+    public required string RequiredConfiguration { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Endpoints/UpdateExtensionBitsProduct/UpdateExtensionBitsProductRequest.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Endpoints/UpdateExtensionBitsProduct/UpdateExtensionBitsProductRequest.cs
@@ -22,14 +22,12 @@ public record UpdateExtensionBitsProductRequest
 {
     protected override string Path => "/bits/extensions";
     public override HttpMethod Method => HttpMethod.Put;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     public override object? ContentObject => Product;
 
     /// <summary>
     /// The product data to update.
     /// </summary>
-    public required UpdateExtensionBitsProductRequestData Product { get; set; }
+    public required UpdateExtensionBitsProductRequestData Product { get; init; }
 }
 
 /// <summary>
@@ -46,25 +44,25 @@ public record UpdateExtensionBitsProductRequestData
     /// The SKU may contain only alphanumeric characters, dashes (-), underscores (_), and periods (.) and is limited to a maximum of 255 characters. 
     /// No spaces.
     /// </remarks>
-    public required ExtensionProductSku Sku { get; set; }
+    public required ExtensionProductSku Sku { get; init; }
     /// <summary>
     /// The product's cost information.
     /// </summary>
-    public required ExtensionProductCost Cost { get; set; }
+    public required ExtensionProductCost Cost { get; init; }
     /// <summary>
     /// The product's name as displayed in the extension. 
     /// </summary>
     /// <remarks>
     /// The maximum length is 255 characters.
     /// </remarks>
-    public required string DisplayName { get; set; }
+    public required string DisplayName { get; init; }
     /// <summary>
     /// Determines whether the product is in development. 
     /// </summary>
     /// <remarks>
     /// Set to <see langword="true"/> if the product is in development and not available for public use. The default is <see langword="false"/>.
     /// </remarks>
-    public bool? InDevelopment { get; set; }
+    public bool? InDevelopment { get; init; }
     /// <summary>
     /// The date and time when the product expires. 
     /// </summary>
@@ -72,7 +70,7 @@ public record UpdateExtensionBitsProductRequestData
     /// If <see langword="null"/>, the product does not expire. 
     /// To disable the product now, set the expiration date to a date in the past.
     /// </remarks>
-    public DateTimeOffset? Expiration { get; set; }
+    public DateTimeOffset? Expiration { get; init; }
     /// <summary>
     /// Determines whether Bits product purchase events are broadcast to all instances of the extension on a channel. 
     /// </summary>
@@ -80,5 +78,5 @@ public record UpdateExtensionBitsProductRequestData
     /// The events are broadcast via the onTransactionComplete helper callback. 
     /// The default is <see langword="false"/>.
     /// </remarks>
-    public bool? IsBroadcast { get; set; }
+    public bool? IsBroadcast { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Extensions/Models/ExtensionProductCost.cs
+++ b/TwitchySharp.Api/Helix/Extensions/Models/ExtensionProductCost.cs
@@ -9,10 +9,10 @@ public record ExtensionProductCost
     /// The amount exchanged for the digital product.
     /// Essentially, this is the amount of bits used.
     /// </summary>
-    public required int Amount { get; set; }
+    public required int Amount { get; init; }
     /// <summary>
     /// The type of currency exchanged.
     /// As of now, this can only be bits.
     /// </summary>
-    public required ExtensionProductCostType Type { get; set; }
+    public required ExtensionProductCostType Type { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Games/Endpoints/GetGames/GetGamesRequest.cs
+++ b/TwitchySharp.Api/Helix/Games/Endpoints/GetGames/GetGamesRequest.cs
@@ -19,8 +19,6 @@ public record GetGamesRequest
 {
     protected override string Path => "/games";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", Games.OfType<GameIdQuery>().Select(x => x.GameId.Value))
@@ -34,7 +32,7 @@ public record GetGamesRequest
     /// You may specify up to 100 games.
     /// Use derived classes <see cref="GameIdQuery"/>, <see cref="GameNameQuery"/>, and <see cref="GameIgdbQuery"/>.
     /// </remarks>
-    public required IEnumerable<GameQuery> Games { get; set; }
+    public required IEnumerable<GameQuery> Games { get; init; }
 }
 
 

--- a/TwitchySharp.Api/Helix/Games/Endpoints/GetTopGames/GetTopGamesRequest.cs
+++ b/TwitchySharp.Api/Helix/Games/Endpoints/GetTopGames/GetTopGamesRequest.cs
@@ -18,8 +18,6 @@ public record GetTopGamesRequest
 {
     protected override string Path => "/games/top";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("first", First?.ToString())
@@ -33,13 +31,13 @@ public record GetTopGamesRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Goals/Endpoints/GetCreatorGoals/GetCreatorGoalsRequest.cs
+++ b/TwitchySharp.Api/Helix/Goals/Endpoints/GetCreatorGoals/GetCreatorGoalsRequest.cs
@@ -32,5 +32,5 @@ public record GetCreatorGoalsRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/AssignGuestStarSlot/AssignGuestStarSlotRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/AssignGuestStarSlot/AssignGuestStarSlotRequest.cs
@@ -31,7 +31,7 @@ public record AssignGuestStarSlotRequest
     /// <summary>
     /// The user id of the broadcaster who is hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -39,12 +39,12 @@ public record AssignGuestStarSlotRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session in which to assign the slot.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The user id of the guest to assign to the slot.
@@ -52,7 +52,7 @@ public record AssignGuestStarSlotRequest
     /// <remarks>
     /// This user must have an invite to the session and have indicated that they are ready to join.
     /// </remarks>
-    public required UserId GuestId { get; set; }
+    public required UserId GuestId { get; init; }
 
     /// <summary>
     /// The slot assignment to give to the user.
@@ -61,5 +61,5 @@ public record AssignGuestStarSlotRequest
     /// Must be a numeric identifier between <c>"1"</c> and <c>"N"</c> where <c>N</c> is the max number of slots for the session.
     /// The max number of slots allowed for the session is reported by a <see cref="GetChannelGuestStarSettingsResponse"/>.
     /// </remarks>
-    public required GuestStarSlotId SlotId { get; set; }
+    public required GuestStarSlotId SlotId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/CreateGuestStarSession/CreateGuestStarSessionRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/CreateGuestStarSession/CreateGuestStarSessionRequest.cs
@@ -32,5 +32,5 @@ public record CreateGuestStarSessionRequest
     /// <remarks>
     /// This must be the same user who created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/DeleteGuestStarInvite/DeleteGuestStarInviteRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/DeleteGuestStarInvite/DeleteGuestStarInviteRequest.cs
@@ -30,7 +30,7 @@ public record DeleteGuestStarInviteRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,15 +38,15 @@ public record DeleteGuestStarInviteRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session that the invite was created for.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The user id of the user to revoke the invite for.
     /// </summary>
-    public required UserId GuestId { get; set; }
+    public required UserId GuestId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/DeleteGuestStarSlot/DeleteGuestStarSlotRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/DeleteGuestStarSlot/DeleteGuestStarSlotRequest.cs
@@ -34,7 +34,7 @@ public record DeleteGuestStarSlotRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -42,25 +42,25 @@ public record DeleteGuestStarSlotRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session from which to remove a user.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The user id of the user to remove from the Guest Star session.
     /// </summary>
-    public required UserId GuestId { get; set; }
+    public required UserId GuestId { get; init; }
 
     /// <summary>
     /// The id of the slot from which to remove the user from.
     /// </summary>
-    public required GuestStarSlotId SlotId { get; set; }
+    public required GuestStarSlotId SlotId { get; init; }
 
     /// <summary>
     /// Determines whether the user should be reinvited to the session, sending them back to the invite queue.
     /// </summary>
-    public bool? ShouldReinviteGuest { get; set; }
+    public bool? ShouldReinviteGuest { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/EndGuestStarSession/EndGuestStarSessionRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/EndGuestStarSession/EndGuestStarSessionRequest.cs
@@ -33,10 +33,10 @@ public record EndGuestStarSessionRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session to end.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetChannelGuestStarSettings/GetChannelGuestStarSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetChannelGuestStarSettings/GetChannelGuestStarSettingsRequest.cs
@@ -28,7 +28,7 @@ public record GetChannelGuestStarSettingsRequest
     /// <summary>
     /// The user id of the broadcaster to get Guest Star settings for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator in the broadcaster's chat.
@@ -36,5 +36,5 @@ public record GetChannelGuestStarSettingsRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetGuestStarInvites/GetGuestStarInvitesRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetGuestStarInvites/GetGuestStarInvitesRequest.cs
@@ -29,7 +29,7 @@ public record GetGuestStarInvitesRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session to get invites for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator in the broadcaster's channel.
@@ -37,10 +37,10 @@ public record GetGuestStarInvitesRequest
     /// <remarks>
     /// This must be the same user who created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The session id to query for invites.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetGuestStarSession/GetGuestStarSessionRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/GetGuestStarSession/GetGuestStarSessionRequest.cs
@@ -28,7 +28,7 @@ public record GetGuestStarSessionRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator in the broadcaster's chat.
@@ -36,5 +36,5 @@ public record GetGuestStarSessionRequest
     /// <remarks>
     /// This user must be the one that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/SendGuestStarInvite/SendGuestStarInviteRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/SendGuestStarInvite/SendGuestStarInviteRequest.cs
@@ -30,7 +30,7 @@ public record SendGuestStarInviteRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,15 +38,15 @@ public record SendGuestStarInviteRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session that you want to send an invite to.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The user id of the user to send the invite to.
     /// </summary>
-    public required UserId GuestId { get; set; }
+    public required UserId GuestId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateChannelGuestStarSettings/UpdateChannelGuestStarSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateChannelGuestStarSettings/UpdateChannelGuestStarSettingsRequest.cs
@@ -31,12 +31,12 @@ public record UpdateChannelGuestStarSettingsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The settings to update.
     /// </summary>
-    public required UpdateChannelGuestStarSettingsRequestData Settings { get; set; }
+    public required UpdateChannelGuestStarSettingsRequestData Settings { get; init; }
 }
 
 /// <summary>
@@ -47,23 +47,23 @@ public record UpdateChannelGuestStarSettingsRequestData
     /// <summary>
     /// Determines if Guest Star moderators have access to control whether a guest is live once assigned to a slot.
     /// </summary>
-    public bool? IsModeratorSendLiveEnabled { get; set; }
+    public bool? IsModeratorSendLiveEnabled { get; init; }
     /// <summary>
     /// Number of slots the Guest Star call interface will allow the host to add to a call. 
     /// Required to be between 1 and 6.
     /// </summary>
-    public int? SlotCount { get; set; }
+    public int? SlotCount { get; init; }
     /// <summary>
     /// Determines if Browser Sources subscribed to sessions on this channel should output audio.
     /// </summary>
-    public bool? IsBrowserSourceAudioEnabled { get; set; }
+    public bool? IsBrowserSourceAudioEnabled { get; init; }
     /// <summary>
     /// Determines how the guests within a session should be laid out within the browser source.
     /// </summary>
-    public GuestStarGroupLayout? GroupLayout { get; set; }
+    public GuestStarGroupLayout? GroupLayout { get; init; }
     /// <summary>
     /// Determines if Guest Star should regenerate the auth token associated with the channel’s browser sources. 
     /// Providing a <see langword="true"/> value for this will immediately invalidate all browser sources previously configured in your streaming software.
     /// </summary>
-    public bool? RegenerateBrowserSources { get; set; }
+    public bool? RegenerateBrowserSources { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateGuestStarSlot/UpdateGuestStarSlotRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateGuestStarSlot/UpdateGuestStarSlotRequest.cs
@@ -31,7 +31,7 @@ public record UpdateGuestStarSlotRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -39,17 +39,17 @@ public record UpdateGuestStarSlotRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session in which to update a slot.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The id of the slot containing the user you want to move.
     /// </summary>
-    public required GuestStarSlotId SourceSlotId { get; set; }
+    public required GuestStarSlotId SourceSlotId { get; init; }
 
     /// <summary>
     /// The id of the slot to move the source user to.
@@ -57,5 +57,5 @@ public record UpdateGuestStarSlotRequest
     /// <remarks>
     /// If the destination slot is occupied, the user assigned will be swapped into the source slot.
     /// </remarks>
-    public GuestStarSlotId? DestinationSlotId { get; set; }
+    public GuestStarSlotId? DestinationSlotId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateGuestStarSlotSettings/UpdateGuestStarSlotSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/GuestStar/Endpoints/UpdateGuestStarSlotSettings/UpdateGuestStarSlotSettingsRequest.cs
@@ -37,7 +37,7 @@ public record UpdateGuestStarSlotSettingsRequest
     /// <summary>
     /// The user id of the broadcaster hosting the Guest Star session.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -45,22 +45,22 @@ public record UpdateGuestStarSlotSettingsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the Guest Star session.
     /// </summary>
-    public required GuestStarSessionId SessionId { get; set; }
+    public required GuestStarSessionId SessionId { get; init; }
 
     /// <summary>
     /// The id of the slot you want to update settings for.
     /// </summary>
-    public required GuestStarSlotId SlotId { get; set; }
+    public required GuestStarSlotId SlotId { get; init; }
 
     /// <summary>
     /// The settings to update.
     /// </summary>
-    public required GuestStarSlotSettings Settings { get; set; }
+    public required GuestStarSlotSettings Settings { get; init; }
 }
 
 /// <summary>
@@ -72,19 +72,19 @@ public record GuestStarSlotSettings
     /// Determines whether the slot is allowed to share their audio with the rest of the session. 
     /// If <see langword="false"/>, the slot will be muted in any views containing the slot.
     /// </summary>
-    public bool? IsAudioEnabled { get; set; }
+    public bool? IsAudioEnabled { get; init; }
     /// <summary>
     /// Determines whether the slot is allowed to share their video with the rest of the session. 
     /// If <see langword="false"/>, the slot will have no video shared in any views containing the slot.
     /// </summary>
-    public bool? IsVideoEnabled { get; set; }
+    public bool? IsVideoEnabled { get; init; }
     /// <summary>
     /// Determines whether the user assigned to this slot is visible/can be heard from any public subscriptions. 
     /// Generally, this determines whether or not the slot is enabled in any broadcasting software integrations.
     /// </summary>
-    public bool? IsLive { get; set; }
+    public bool? IsLive { get; init; }
     /// <summary>
     /// Value from 0-100 that controls the audio volume for shared views containing the slot.
     /// </summary>
-    public int? Volume { get; set; }
+    public int? Volume { get; init; }
 }

--- a/TwitchySharp.Api/Helix/HypeTrain/Endpoints/GetHypeTrainStatus/GetHypeTrainStatusRequest.cs
+++ b/TwitchySharp.Api/Helix/HypeTrain/Endpoints/GetHypeTrainStatus/GetHypeTrainStatusRequest.cs
@@ -30,5 +30,5 @@ public record GetHypeTrainStatusRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/AddBlockedTerm/AddBlockedTermRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/AddBlockedTerm/AddBlockedTermRequest.cs
@@ -30,7 +30,7 @@ public record AddBlockedTermRequest : TwitchHelixRequest<AddBlockedTermResponse>
     /// <summary>
     /// The user id of the broadcaster (channel) to add a blocked term to.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,12 +38,12 @@ public record AddBlockedTermRequest : TwitchHelixRequest<AddBlockedTermResponse>
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The blocked term to create.
     /// </summary>
-    public required AddBlockedTermRequestData Term { get; set; }
+    public required AddBlockedTermRequestData Term { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/AddChannelModerator/AddChannelModeratorRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/AddChannelModerator/AddChannelModeratorRequest.cs
@@ -33,10 +33,10 @@ public record AddChannelModeratorRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the user to add as a moderator.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/AddSuspiciousStatusToChatUser/AddSuspiciousStatusToChatUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/AddSuspiciousStatusToChatUser/AddSuspiciousStatusToChatUserRequest.cs
@@ -29,7 +29,7 @@ public record AddSuspiciousStatusToChatUserRequest
     /// <summary>
     /// The user id of the broadcaster (channel) in whose chat the suspicious user status is being applied.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the moderator (or the broadcaster) to update the suspicious user status on behalf of.
@@ -37,12 +37,12 @@ public record AddSuspiciousStatusToChatUserRequest
     /// <remarks>
     /// This should be the same user that created the user access token for the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The request data.
     /// </summary>
-    public required AddSuspiciousStatusToChatUserRequestData Data { get; set; }
+    public required AddSuspiciousStatusToChatUserRequestData Data { get; init; }
 }
 
 /// <summary>
@@ -53,9 +53,9 @@ public record AddSuspiciousStatusToChatUserRequestData
     /// <summary>
     /// The id of the user to add suspicious user status to.
     /// </summary>
-    public required string UserId { get; set; }
+    public required string UserId { get; init; }
     /// <summary>
     /// The type of suspicious user status to add.
     /// </summary>
-    public required SuspiciousUserStatus Status { get; set; }
+    public required SuspiciousUserStatus Status { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/BanUser/BanUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/BanUser/BanUserRequest.cs
@@ -32,7 +32,7 @@ public record BanUserRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to ban or time out a user from.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -40,12 +40,12 @@ public record BanUserRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// Information used to set the user to ban or time out.
     /// </summary>
-    public required BanUserRequestData Ban { get; set; }
+    public required BanUserRequestData Ban { get; init; }
 }
 
 /// <summary>
@@ -56,7 +56,7 @@ public record BanUserRequestData
     /// <summary>
     /// Information about the specific user to ban or time out.
     /// </summary>
-    public required UserToBan Data { get; set; } // Really Twitch?
+    public required UserToBan Data { get; init; } // Really Twitch?
 }
 
 /// <summary>
@@ -67,7 +67,7 @@ public record UserToBan
     /// <summary>
     /// The user id of the user to ban or time out.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
     /// <summary>
     /// Set this property to issue a time-out, leave <see langword="null"/> to issue a ban.
     /// Time-out durations are measured in <b>seconds</b>, with the minimum duration being 1 second, and the maximum being 1,209,600 seconds (2 weeks).
@@ -75,9 +75,9 @@ public record UserToBan
     /// Also note that adding a time-out duration to a user does not overwrite a ban if they have one.
     /// </summary>
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public TimeSpan? Duration { get; set; }
+    public TimeSpan? Duration { get; init; }
     /// <summary>
     /// Caller-defined text that is displayed to the banned user as the reason for their ban or time-out.
     /// </summary>
-    public string? Reason { get; set; }
+    public string? Reason { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/CheckAutoModStatus/CheckAutoModStatusRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/CheckAutoModStatus/CheckAutoModStatusRequest.cs
@@ -51,12 +51,12 @@ public record CheckAutoModStatusRequest
     /// <remarks>
     /// This must be the same user who created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The messages to check against the channel's AutoMod.
     /// </summary>
-    public required CheckAutoModStatusRequestData Messages { get; set; }
+    public required CheckAutoModStatusRequestData Messages { get; init; }
 }
 
 /// <summary>
@@ -69,7 +69,7 @@ public record CheckAutoModStatusRequestData
     /// The list must contain at least one message and may contain up to a maximum of 100 messages.
     /// </summary>
     [JsonPropertyName("data")]
-    public required AutoModStatusMessage[] Messages { get; set; }
+    public required AutoModStatusMessage[] Messages { get; init; }
 }
 
 /// <summary>
@@ -82,10 +82,10 @@ public record AutoModStatusMessage
     /// The value of this property will be the same as <see cref="AutoModStatus.MessageId"/> in the response.
     /// </summary>
     [JsonPropertyName("msg_id")]
-    public required string MessageId { get; set; }
+    public required string MessageId { get; init; }
     /// <summary>
     /// The message to check against the AutoMod.
     /// </summary>
     [JsonPropertyName("msg_text")]
-    public required string MessageText { get; set; }
+    public required string MessageText { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/DeleteChatMessages/DeleteChatMessagesRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/DeleteChatMessages/DeleteChatMessagesRequest.cs
@@ -29,7 +29,7 @@ public record DeleteChatMessagesRequest
     /// <summary>
     /// The user id of the broadcaster (channel) whose chat to delete a chat message from.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -37,7 +37,7 @@ public record DeleteChatMessagesRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the message to remove.
@@ -51,5 +51,5 @@ public record DeleteChatMessagesRequest
     /// </list>
     /// If this parameter is <see langword="null"/>, the request removes all messages in the chatroom.
     /// </remarks>
-    public MessageId? MessageId { get; set; }
+    public MessageId? MessageId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetAutoModSettings/GetAutoModSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetAutoModSettings/GetAutoModSettingsRequest.cs
@@ -30,7 +30,7 @@ public record GetAutoModSettingsRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to get AutoMod settings for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,5 +38,5 @@ public record GetAutoModSettingsRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetBannedUsers/GetBannedUsersRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetBannedUsers/GetBannedUsersRequest.cs
@@ -36,7 +36,7 @@ public record GetBannedUsersRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// A list of user ids used to filter the results.
@@ -46,19 +46,19 @@ public record GetBannedUsersRequest
     /// The returned list includes only those users that were banned or put in a timeout.
     /// The list is returned in the same order that you specified the ids.
     /// </remarks>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
 
     /// <remarks>
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetBlockedTerms/GetBlockedTermsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetBlockedTerms/GetBlockedTermsRequest.cs
@@ -32,7 +32,7 @@ public record GetBlockedTermsRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to get blocked terms for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -40,14 +40,14 @@ public record GetBlockedTermsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <remarks>
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetModeratedChannels/GetModeratedChannelsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetModeratedChannels/GetModeratedChannelsRequest.cs
@@ -33,14 +33,14 @@ public record GetModeratedChannelsRequest
     /// <remarks>
     /// This must be the same user that created the access token.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <remarks>
     /// Minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetModerators/GetModeratorsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetModerators/GetModeratorsRequest.cs
@@ -35,7 +35,7 @@ public record GetModeratorsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// A list of user ids used to filter the results.
@@ -45,14 +45,14 @@ public record GetModeratorsRequest
     /// The returned list includes only the users from the list who are moderators in the broadcaster's channel.
     /// The list is returned in the same order as you specified the ids.
     /// </remarks>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
 
     /// <remarks>
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetShieldModeStatus/GetShieldModeStatusRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetShieldModeStatus/GetShieldModeStatusRequest.cs
@@ -28,7 +28,7 @@ public record GetShieldModeStatusRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to get Shield Mode status for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -36,5 +36,5 @@ public record GetShieldModeStatusRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/GetUnbanRequests/GetUnbanRequestsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/GetUnbanRequests/GetUnbanRequestsRequest.cs
@@ -33,7 +33,7 @@ public record GetUnbanRequestsRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to get unban requests for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -41,21 +41,21 @@ public record GetUnbanRequestsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// Filter unban requests by status.
     /// </summary>
-    public required UnbanRequestStatus Status { get; set; }
+    public required UnbanRequestStatus Status { get; init; }
 
     /// <summary>
     /// Filter unban requests by banned user.
     /// </summary>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 
     /// <inheritdoc cref="PaginationAmount"/>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/ManageHeldAutoModMessages/ManageHeldAutoModMessagesRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/ManageHeldAutoModMessages/ManageHeldAutoModMessagesRequest.cs
@@ -27,7 +27,7 @@ public record ManageHeldAutoModMessagesRequest
     /// <summary>
     /// Data used to identify the message and select the action.
     /// </summary>
-    public required ManageHeldAutoModMessagesRequestData MessageAction { get; set; }
+    public required ManageHeldAutoModMessagesRequestData MessageAction { get; init; }
 }
 
 /// <summary>
@@ -39,15 +39,15 @@ public record ManageHeldAutoModMessagesRequestData
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
     /// This must be the same user that created the access token used in the <see cref="ManageHeldAutoModMessagesRequest"/>.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
     /// <summary>
     /// The id of the message to allow or deny.
     /// </summary>
     [JsonPropertyName("msg_id")]
-    public required MessageId MessageId { get; set; }
+    public required MessageId MessageId { get; init; }
     /// <summary>
     /// The action to take for the message.
     /// Use the static definitions on the <see cref="AutoModAction"/> class to set this.
     /// </summary>
-    public required AutoModAction Action { get; set; }
+    public required AutoModAction Action { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveBlockedTerm/RemoveBlockedTermRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveBlockedTerm/RemoveBlockedTermRequest.cs
@@ -29,7 +29,7 @@ public record RemoveBlockedTermRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to remove a blocked term from.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -37,10 +37,10 @@ public record RemoveBlockedTermRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the blocked term to remove.
     /// </summary>
-    public required AutomodBlockedTermId BlockedTermId { get; set; }
+    public required AutomodBlockedTermId BlockedTermId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveChannelModerator/RemoveChannelModeratorRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveChannelModerator/RemoveChannelModeratorRequest.cs
@@ -33,10 +33,10 @@ public record RemoveChannelModeratorRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the moderator to remove from the broadcaster's channel.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveSuspiciousStatusFromChatUser/RemoveSuspiciousStatusFromChatUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/RemoveSuspiciousStatusFromChatUser/RemoveSuspiciousStatusFromChatUserRequest.cs
@@ -29,7 +29,7 @@ public record RemoveSuspiciousStatusFromChatUserRequest
     /// <summary>
     /// The user id of the broadcaster (channel) in whose chat to remove the suspicious user status.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the moderator (or the broadcaster) to remove the suspicious user status on behalf of.
@@ -37,10 +37,10 @@ public record RemoveSuspiciousStatusFromChatUserRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the user to remove the suspicious user status on.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/ResolveUnbanRequests/ResolveUnbanRequestsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/ResolveUnbanRequests/ResolveUnbanRequestsRequest.cs
@@ -31,7 +31,7 @@ public record ResolveUnbanRequestsRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to resolve the unban request for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -39,17 +39,17 @@ public record ResolveUnbanRequestsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The id of the unban request to resolve.
     /// </summary>
-    public required UnbanRequestId UnbanRequestId { get; set; }
+    public required UnbanRequestId UnbanRequestId { get; init; }
 
     /// <summary>
     /// The resolution status to set the unban request to.
     /// </summary>
-    public required UnbanRequestResolutionStatus Status { get; set; }
+    public required UnbanRequestResolutionStatus Status { get; init; }
 
     /// <summary>
     /// Caller-defined text that is added to the unban request.
@@ -57,5 +57,5 @@ public record ResolveUnbanRequestsRequest
     /// <remarks>
     /// This can be a maximum of 500 characters.
     /// </remarks>
-    public string? ResolutionText { get; set; }
+    public string? ResolutionText { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/UnbanUser/UnbanUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/UnbanUser/UnbanUserRequest.cs
@@ -29,7 +29,7 @@ public record UnbanUserRequest
     /// <summary>
     /// The user id of the broadcaster (channel) that the user will be unbanned on.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -37,10 +37,10 @@ public record UnbanUserRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The user id of the user to unban or remove a time-out on.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/UpdateAutoModSettings/UpdateAutoModSettingsRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/UpdateAutoModSettings/UpdateAutoModSettingsRequest.cs
@@ -32,7 +32,7 @@ public record UpdateAutoModSettingsRequest
     /// <summary>
     /// The user id of the broadcaster (channel) that you want to update AutoMod settings for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -40,13 +40,13 @@ public record UpdateAutoModSettingsRequest
     /// <remarks>
     /// This must be the same user that created the access token.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The settings to update.
     /// Use derived classes <see cref="UpdateAutoModOverallLevelData"/> and <see cref="UpdateAutoModCustomLevelsData"/>.
     /// </summary>
-    public required UpdateAutoModSettingsRequestData Settings { get; set; }
+    public required UpdateAutoModSettingsRequestData Settings { get; init; }
 }
 
 /// <summary>
@@ -60,15 +60,15 @@ public record UpdateAutoModSettingsRequest
 /// </remarks>
 public record UpdateAutoModSettingsRequestData
 {
-    public AutomodFilteringLevel? OverallLevel { get; protected set; }
-    public AutomodFilteringLevel? Aggression { get; protected set; }
-    public AutomodFilteringLevel? Bullying { get; protected set; }
-    public AutomodFilteringLevel? Disability { get; protected set; }
-    public AutomodFilteringLevel? Misogyny { get; protected set; }
-    public AutomodFilteringLevel? RaceEthnicityOrReligion { get; protected set; }
-    public AutomodFilteringLevel? SexBasedTerms { get; protected set; }
-    public AutomodFilteringLevel? SexualitySexOrGender { get; protected set; }
-    public AutomodFilteringLevel? Swearing { get; protected set; }
+    public AutomodFilteringLevel? OverallLevel { get; protected init; }
+    public AutomodFilteringLevel? Aggression { get; protected init; }
+    public AutomodFilteringLevel? Bullying { get; protected init; }
+    public AutomodFilteringLevel? Disability { get; protected init; }
+    public AutomodFilteringLevel? Misogyny { get; protected init; }
+    public AutomodFilteringLevel? RaceEthnicityOrReligion { get; protected init; }
+    public AutomodFilteringLevel? SexBasedTerms { get; protected init; }
+    public AutomodFilteringLevel? SexualitySexOrGender { get; protected init; }
+    public AutomodFilteringLevel? Swearing { get; protected init; }
     protected UpdateAutoModSettingsRequestData() { }
     /// <summary>
     /// Update settings using an instance of <see cref="AutoModSettings"/>.
@@ -117,21 +117,21 @@ public record UpdateAutoModCustomLevelsData
     : UpdateAutoModSettingsRequestData
 {
     /// <inheritdoc cref="AutoModSettings.Aggression"/>
-    public new AutomodFilteringLevel Aggression { get; set; }
+    public new AutomodFilteringLevel Aggression { get; init; }
     /// <inheritdoc cref="AutoModSettings.Bullying"/>
-    public new AutomodFilteringLevel Bullying { get; set; }
+    public new AutomodFilteringLevel Bullying { get; init; }
     /// <inheritdoc cref="AutoModSettings.Disability"/>
-    public new AutomodFilteringLevel Disability { get; set; }
+    public new AutomodFilteringLevel Disability { get; init; }
     /// <inheritdoc cref="AutoModSettings.Misogyny"/>
-    public new AutomodFilteringLevel Misogyny { get; set; }
+    public new AutomodFilteringLevel Misogyny { get; init; }
     /// <inheritdoc cref="AutoModSettings.RaceEthnicityOrReligion"/>
-    public new AutomodFilteringLevel RaceEthnicityOrReligion { get; set; }
+    public new AutomodFilteringLevel RaceEthnicityOrReligion { get; init; }
     /// <inheritdoc cref="AutoModSettings.SexBasedTerms"/>
-    public new AutomodFilteringLevel SexBasedTerms { get; set; }
+    public new AutomodFilteringLevel SexBasedTerms { get; init; }
     /// <inheritdoc cref="AutoModSettings.SexualitySexOrGender"/>
-    public new AutomodFilteringLevel SexualitySexOrGender { get; set; }
+    public new AutomodFilteringLevel SexualitySexOrGender { get; init; }
     /// <inheritdoc cref="AutoModSettings.Swearing"/>
-    public new AutomodFilteringLevel Swearing { get; set; }
+    public new AutomodFilteringLevel Swearing { get; init; }
 
     /// <inheritdoc cref="UpdateAutoModCustomLevelsData"/>
     public UpdateAutoModCustomLevelsData()

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/UpdateShieldModStatus/UpdateShieldModeStatusRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/UpdateShieldModStatus/UpdateShieldModeStatusRequest.cs
@@ -30,7 +30,7 @@ public record UpdateShieldModeStatusRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to update Shield Mode status for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -38,12 +38,12 @@ public record UpdateShieldModeStatusRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The Shield Mode status to update to.
     /// </summary>
-    public required UpdateShieldModeStatusRequestData ShieldModeStatus { get; set; }
+    public required UpdateShieldModeStatusRequestData ShieldModeStatus { get; init; }
 }
 
 /// <summary>
@@ -57,5 +57,5 @@ public record UpdateShieldModeStatusRequestData
     /// <remarks>
     /// Set to <see langword="true"/> to activate Shield Mode; otherwise, <see langword="false"/> to deactivate Shield Mode.
     /// </remarks>
-    public required bool IsActive { get; set; }
+    public required bool IsActive { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Moderation/Endpoints/WarnChatUser/WarnChatUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Moderation/Endpoints/WarnChatUser/WarnChatUserRequest.cs
@@ -31,7 +31,7 @@ public record WarnChatUserRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to issue to warning in.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster or a moderator of the broadcaster's channel.
@@ -39,12 +39,12 @@ public record WarnChatUserRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId ModeratorId { get; set; }
+    public required UserId ModeratorId { get; init; }
 
     /// <summary>
     /// The warning data.
     /// </summary>
-    public required WarnChatUserRequestData Warning { get; set; }
+    public required WarnChatUserRequestData Warning { get; init; }
 }
 
 /// <summary>
@@ -55,7 +55,7 @@ public record WarnChatUserRequestData
     /// <summary>
     /// The warning data.
     /// </summary>
-    public required ChatUserWarning Data { get; set; }
+    public required ChatUserWarning Data { get; init; }
 }
 
 /// <summary>
@@ -66,12 +66,12 @@ public record ChatUserWarning
     /// <summary>
     /// The id of the user to warn.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
     /// <summary>
     /// The custom reason for the warning.
     /// </summary>
     /// <remarks>
     /// Can be a maximum of 500 characters.
     /// </remarks>
-    public required string Reason { get; set; }
+    public required string Reason { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Polls/Endpoints/CreatePoll/CreatePollRequest.cs
+++ b/TwitchySharp.Api/Helix/Polls/Endpoints/CreatePoll/CreatePollRequest.cs
@@ -29,7 +29,7 @@ public record CreatePollRequest
     /// <summary>
     /// The poll to create.
     /// </summary>
-    public required CreatePollRequestData Poll { get; set; }
+    public required CreatePollRequestData Poll { get; init; }
 }
 
 /// <summary>
@@ -41,32 +41,32 @@ public record CreatePollRequestData
     /// The user id of the broadcaster (channel) to create the poll for.
     /// This must be the same user that created the user access token in the request.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The question that viewers will vote on.
     /// The question may contain a maximum of 60 characters.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
     /// <summary>
     /// A list of choices that viewers may choose from. 
     /// The list must contain a minimum of 2 choices and up to a maximum of 5 choices.
     /// </summary>
-    public required CreatePollChoice[] Choices { get; set; }
+    public required CreatePollChoice[] Choices { get; init; }
     /// <summary>
     /// The length of time that the poll will run for. 
     /// The minimum is 15 seconds and the maximum is 1800 seconds (30 minutes).
     /// </summary>
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public required TimeSpan Duration { get; set; }
+    public required TimeSpan Duration { get; init; }
     /// <summary>
     /// Determines whether viewers may cast additional votes using Channel Points.
     /// If set to <see langword="true"/>, the amount of Channel Points required per additional vote is set by <see cref="ChannelPointsPerVote"/>.
     /// The default value is <see langword="false"/>.
     /// </summary>
-    public bool? ChannelPointsVotingEnabled { get; set; }
+    public bool? ChannelPointsVotingEnabled { get; init; }
     /// <summary>
     /// If <see cref="ChannelPointsVotingEnabled"/> is set to <see langword="true"/>, the amount of points required to cast one additional vote.
     /// The minimum value is 1 and the maximum is 1,000,000.
     /// </summary>
-    public int? ChannelPointsPerVote { get; set; }
+    public int? ChannelPointsPerVote { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Polls/Endpoints/CreatePoll/Models/CreatePollChoice.cs
+++ b/TwitchySharp.Api/Helix/Polls/Endpoints/CreatePoll/Models/CreatePollChoice.cs
@@ -9,5 +9,5 @@ public record CreatePollChoice
     /// The title of the choice that is visible to viewers.
     /// This may contain up to 25 characters.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Polls/Endpoints/EndPoll/EndPollRequest.cs
+++ b/TwitchySharp.Api/Helix/Polls/Endpoints/EndPoll/EndPollRequest.cs
@@ -26,7 +26,7 @@ public record EndPollRequest
     /// <summary>
     /// Data used to end the poll.
     /// </summary>
-    public required EndPollRequestData Poll { get; set; }
+    public required EndPollRequestData Poll { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/Polls/Endpoints/GetPolls/GetPollsRequest.cs
+++ b/TwitchySharp.Api/Helix/Polls/Endpoints/GetPolls/GetPollsRequest.cs
@@ -36,7 +36,7 @@ public record GetPollsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// Filter the list of polls by poll id.
@@ -46,7 +46,7 @@ public record GetPollsRequest
     /// Specify this parameter only if you want to filter the list that the request returns.
     /// The endpoint ignores duplicate ids and those not owned by this broadcaster.
     /// </remarks>
-    public IEnumerable<PollId>? PollIds { get; set; }
+    public IEnumerable<PollId>? PollIds { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -55,8 +55,8 @@ public record GetPollsRequest
     /// The minimum page size is 1 item per page and the maximum is 20 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Predictions/Endpoints/CreatePrediction/CreatePredictionRequest.cs
+++ b/TwitchySharp.Api/Helix/Predictions/Endpoints/CreatePrediction/CreatePredictionRequest.cs
@@ -30,7 +30,7 @@ public record CreatePredictionRequest
     /// <summary>
     /// The new prediction to create and start.
     /// </summary>
-    public required CreatePredictionRequestData Prediction { get; set; }
+    public required CreatePredictionRequestData Prediction { get; init; }
 }
 
 /// <summary>
@@ -42,21 +42,21 @@ public record CreatePredictionRequestData
     /// The user id of the broadcaster (channel) to create the prediction for.
     /// This must be the same user that created the user access token in the <see cref="CreatePredictionRequest"/>.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The question that the prediction is asking.
     /// This is limited to a maximum of 45 characters.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
     /// <summary>
     /// The list of possible outcomes that the viewers may choose from.
     /// This list must contain a minimum of 2 choices and up to a maximum of 10 choices.
     /// </summary>
-    public required CreatePredictionOutcome[] Outcomes { get; set; }
+    public required CreatePredictionOutcome[] Outcomes { get; init; }
     /// <summary>
     /// The length of time that the prediction will be active for.
     /// The minimum is 30 seconds and the maximum is 1800 seconds (30 minutes).
     /// </summary>
     [JsonConverter(typeof(SecondsTimeSpanJsonConverter))]
-    public required TimeSpan PredictionWindow { get; set; }
+    public required TimeSpan PredictionWindow { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Predictions/Endpoints/CreatePrediction/Models/CreatePredictionOutcome.cs
+++ b/TwitchySharp.Api/Helix/Predictions/Endpoints/CreatePrediction/Models/CreatePredictionOutcome.cs
@@ -9,5 +9,5 @@ public record CreatePredictionOutcome
     /// The text of one of the outcomes that the viewer may select. 
     /// The title is limited to a maximum of 25 characters.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Predictions/Endpoints/EndPrediction/EndPredictionRequest.cs
+++ b/TwitchySharp.Api/Helix/Predictions/Endpoints/EndPrediction/EndPredictionRequest.cs
@@ -25,7 +25,7 @@ public record EndPredictionRequest
     /// Data used to update the prediction.
     /// Use derived classes <see cref="ResolvePrediction"/>, <see cref="CancelPrediction"/>, and <see cref="LockPrediction"/>.
     /// </summary>
-    public required EndPredictionRequestData Prediction { get; set; }
+    public required EndPredictionRequestData Prediction { get; init; }
 }
 
 /// <summary>
@@ -61,22 +61,22 @@ public record EndPredictionRequestData
     /// The user id of the broadcaster (channel) that owns the prediction.
     /// This must be the same user that created the user access token in the <see cref="EndPredictionRequest"/>.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The id of the prediction to update.
     /// </summary>
-    public required PredictionId Id { get; set; }
+    public required PredictionId Id { get; init; }
     /// <summary>
     /// The status to set the prediction to.
     /// Only currently running predictions can be updated, and <see cref="ChatPredictionStatus.Locked"/> predictions can only be set to <see cref="UpdateChatPredictionStatus.Resolved"/> or <see cref="UpdateChatPredictionStatus.Cancelled"/> (a locked prediction cannot be unlocked).
     /// If setting a prediction to <see cref="UpdateChatPredictionStatus.Locked"/>, the broadcaster has 24 hours to cancel or resolve the prediction before it will be automatically cancelled.
     /// </summary>
-    public UpdateChatPredictionStatus Status { get; protected set; }
+    public UpdateChatPredictionStatus Status { get; protected init; }
     /// <summary>
     /// The id of the winning outcome.
     /// This must be set if <see cref="Status"/> is set to <see cref="UpdateChatPredictionStatus.Resolved"/>.
     /// </summary>
-    public PredictionOutcomeId? WinningOutcomeId { get; protected set; }
+    public PredictionOutcomeId? WinningOutcomeId { get; protected init; }
     /// <summary>
     /// <inheritdoc cref="EndPredictionRequestData"/>
     /// Use this constructor to use a custom update status (e.g., if a new status is added to Twitch API and isn't available on the <see cref="UpdateChatPredictionStatus"/> class).

--- a/TwitchySharp.Api/Helix/Predictions/Endpoints/GetPredictions/GetPredictionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Predictions/Endpoints/GetPredictions/GetPredictionsRequest.cs
@@ -35,7 +35,7 @@ public record GetPredictionsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// Filter the returned list by prediction id.
@@ -44,7 +44,7 @@ public record GetPredictionsRequest
     /// You may specify a maximum of 25 ids.
     /// The endpoint ignores duplicate ids and those not owned by the broadcaster.
     /// </remarks>
-    public IEnumerable<PredictionId>? PredictionIds { get; set; }
+    public IEnumerable<PredictionId>? PredictionIds { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>.
@@ -53,8 +53,8 @@ public record GetPredictionsRequest
     /// The minimum page size is 1 item per page and the maximum is 25 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Raids/Endpoints/CancelRaid/CancelRaidRequest.cs
+++ b/TwitchySharp.Api/Helix/Raids/Endpoints/CancelRaid/CancelRaidRequest.cs
@@ -31,5 +31,5 @@ public record CancelRaidRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to cancel a pending raid for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Raids/Endpoints/StartRaid/StartRaidRequest.cs
+++ b/TwitchySharp.Api/Helix/Raids/Endpoints/StartRaid/StartRaidRequest.cs
@@ -31,10 +31,10 @@ public record StartRaidRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId FromBroadcasterId { get; set; }
+    public required UserId FromBroadcasterId { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster (channel) to send the raid to.
     /// </summary>
-    public required UserId ToBroadcasterId { get; set; }
+    public required UserId ToBroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/CreateChannelStreamScheduleSegment/CreateChannelStreamScheduleSegmentRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/CreateChannelStreamScheduleSegment/CreateChannelStreamScheduleSegmentRequest.cs
@@ -32,12 +32,12 @@ public record CreateChannelStreamScheduleSegmentRequest
     /// The user id of the broadcaster (channel) that owns the schedule to add the broadcast segment to.
     /// This must be the same user that created the access token.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The segment to add.
     /// </summary>
-    public required CreateChannelStreamScheduleSegmentRequestData ScheduleSegment { get; set; }
+    public required CreateChannelStreamScheduleSegmentRequestData ScheduleSegment { get; init; }
 }
 
 /// <summary>
@@ -48,12 +48,12 @@ public record CreateChannelStreamScheduleSegmentRequestData
     /// <summary>
     /// The date and time that the broadcast segment starts.
     /// </summary>
-    public required DateTimeOffset StartTime { get; set; }
+    public required DateTimeOffset StartTime { get; init; }
     /// <summary>
     /// The time zone where the broadcast takes place.
     /// </summary>
     [JsonConverter(typeof(IanaTimeZoneJsonConverter))]
-    public required TimeZoneInfo Timezone { get; set; }
+    public required TimeZoneInfo Timezone { get; init; }
     /// <summary>
     /// The length of time that the broadcast is scheduled to run. 
     /// </summary>
@@ -61,20 +61,20 @@ public record CreateChannelStreamScheduleSegmentRequestData
     /// The duration can range from 30 minutes to 23 hours.
     /// </remarks>
     [JsonConverter(typeof(MinutesTimeSpanJsonConverter))]
-    public required TimeSpan Duration { get; set; }
+    public required TimeSpan Duration { get; init; }
     /// <summary>
     /// Determines whether the broadcast recurs weekly. 
     /// Set to <see langword="true"/> if the broadcast will recur weekly. 
     /// Only partners and affiliates may add non-recurring broadcasts.
     /// </summary>
-    public bool? IsRecurring { get; set; }
+    public bool? IsRecurring { get; init; }
     /// <summary>
     /// The id of the category for the scheduled stream segment.
     /// </summary>
-    public GameId? CategoryId { get; set; }
+    public GameId? CategoryId { get; init; }
     /// <summary>
     /// The title for the scheduled broadcast.
     /// This may contain up to a maximum of 140 characters.
     /// </summary>
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/DeleteChannelStreamScheduleSegment/DeleteChannelStreamScheduleSegmentRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/DeleteChannelStreamScheduleSegment/DeleteChannelStreamScheduleSegmentRequest.cs
@@ -33,10 +33,10 @@ public record DeleteChannelStreamScheduleSegmentRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the segment to remove.
     /// </summary>
-    public required StreamScheduleSegmentId SegmentId { get; set; }
+    public required StreamScheduleSegmentId SegmentId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/GetChannelCalendar/GetChannelICalendarRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/GetChannelCalendar/GetChannelICalendarRequest.cs
@@ -20,7 +20,6 @@ public record GetChannelICalendarRequest
     public override HttpMethod Method => HttpMethod.Get;
     // This endpoint does not require any authentication
     protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.None;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -28,5 +27,5 @@ public record GetChannelICalendarRequest
     /// <summary>
     /// The user id of the broadcaster (channel) to get the streaming schedule for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/GetChannelStreamSchedule/GetChannelStreamScheduleRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/GetChannelStreamSchedule/GetChannelStreamScheduleRequest.cs
@@ -22,8 +22,6 @@ public record GetChannelStreamScheduleRequest
 {
     protected override string Path => "/schedule";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId)
@@ -35,7 +33,7 @@ public record GetChannelStreamScheduleRequest
     /// <summary>
     /// The user id of the broadcaster to get the streaming schedule for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The ids of the segments to get.
@@ -43,7 +41,7 @@ public record GetChannelStreamScheduleRequest
     /// <remarks>
     /// You may specify a maximum of 100 ids.
     /// </remarks>
-    public IEnumerable<StreamScheduleSegmentId>? Ids { get; set; }
+    public IEnumerable<StreamScheduleSegmentId>? Ids { get; init; }
 
     /// <summary>
     /// The date and time that identifies when in the broadcaster's schedule to start returning segments.
@@ -51,7 +49,7 @@ public record GetChannelStreamScheduleRequest
     /// <remarks>
     /// If not specified, the request returns segments starting after the current UTC date and time.
     /// </remarks>
-    public DateTimeOffset? StartTime { get; set; }
+    public DateTimeOffset? StartTime { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -60,8 +58,8 @@ public record GetChannelStreamScheduleRequest
     /// The minimum page size is 1 item per page and the maximum is 25 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/UpdateChannelStreamSchedule/UpdateChannelStreamScheduleRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/UpdateChannelStreamSchedule/UpdateChannelStreamScheduleRequest.cs
@@ -35,7 +35,7 @@ public record UpdateChannelStreamScheduleRequest
     /// <summary>
     /// The request parameters.
     /// </summary>
-    public required UpdateChannelStreamScheduleRequestParameters Settings { get; set; }
+    public required UpdateChannelStreamScheduleRequestParameters Settings { get; init; }
 }
 
 /// <summary>
@@ -77,23 +77,23 @@ public record UpdateChannelStreamScheduleRequestParameters
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// Determines whether the broadcaster has scheduled a vacation. 
     /// Set to <see langword="true"/> to enable Vacation Mode and add vacation dates, or <see langword="false"/> to cancel a previously scheduled vacation.
     /// </summary>
-    public bool? IsVacationEnabled { get; private set; }
+    public bool? IsVacationEnabled { get; private init; }
     /// <summary>
     /// The date and time of when the broadcaster’s vacation starts. 
     /// </summary>
-    public DateTimeOffset? VacationStartTime { get; private set; }
+    public DateTimeOffset? VacationStartTime { get; private init; }
     /// <summary>
     /// The date and time of when the broadcaster’s vacation ends.
     /// </summary>
-    public DateTimeOffset? VacationEndTime { get; private set; }
+    public DateTimeOffset? VacationEndTime { get; private init; }
     /// <summary>
     /// The time zone that the broadcaster broadcasts from.
     /// </summary>
     [JsonConverter(typeof(IanaTimeZoneJsonConverter))]
-    public TimeZoneInfo? Timezone { get; private set; }
+    public TimeZoneInfo? Timezone { get; private init; }
 }

--- a/TwitchySharp.Api/Helix/Schedule/Endpoints/UpdateChannelStreamScheduleSegment/UpdateChannelStreamScheduleSegmentRequest.cs
+++ b/TwitchySharp.Api/Helix/Schedule/Endpoints/UpdateChannelStreamScheduleSegment/UpdateChannelStreamScheduleSegmentRequest.cs
@@ -37,17 +37,17 @@ public record UpdateChannelStreamScheduleSegmentRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 
     /// <summary>
     /// The id of the segment to update.
     /// </summary>
-    public required StreamScheduleSegmentId SegmentId { get; set; }
+    public required StreamScheduleSegmentId SegmentId { get; init; }
 
     /// <summary>
     /// The new settings to update the segment to.
     /// </summary>
-    public required UpdateChannelStreamScheduleSegmentRequestData SegmentSettings { get; set; }
+    public required UpdateChannelStreamScheduleSegmentRequestData SegmentSettings { get; init; }
 }
 
 /// <summary>
@@ -60,22 +60,22 @@ public record UpdateChannelStreamScheduleSegmentRequestData
     /// The date and time that the broadcast segment starts.
     /// <b>Note:</b> Only partners and affiliates may update a broadcast’s start time and only for non-recurring segments.
     /// </summary>
-    public DateTimeOffset? StartTime { get; set; }
+    public DateTimeOffset? StartTime { get; init; }
     /// <summary>
     /// The length of time, in <b>minutes</b>, that the broadcast is scheduled to run. 
     /// The duration must be in the range 30 through 1380 (23 hours).
     /// </summary>
     [JsonConverter(typeof(MinutesTimeSpanJsonConverter))]
-    public TimeSpan? Duration { get; set; }
+    public TimeSpan? Duration { get; init; }
     /// <summary>
     /// The id of the category for the scheduled stream segment.
     /// </summary>
-    public GameId? CategoryId { get; set; }
+    public GameId? CategoryId { get; init; }
     /// <summary>
     /// The title for the scheduled broadcast.
     /// This may contain up to a maximum of 140 characters.
     /// </summary>
-    public string? Title { get; set; }
+    public string? Title { get; init; }
     /// <summary>
     /// Determines whether the broadcast is canceled. 
     /// Set to <see langword="true"/> to cancel the segment.
@@ -83,11 +83,11 @@ public record UpdateChannelStreamScheduleSegmentRequestData
     /// <b>Note:</b> For recurring segments, the API cancels the first segment after the current UTC date and time and not the specified segment (unless the specified segment is the next segment after the current UTC date and time).
     /// </para>
     /// </summary>
-    public bool? IsCancelled { get; set; }
+    public bool? IsCancelled { get; init; }
     /// <summary>
     /// The time zone where the broadcast takes place. 
     /// Specify the time zone using <see href="https://www.iana.org/time-zones">IANA time zone database</see> format (for example, <c>"America/New_York"</c>).
     /// </summary>
     [JsonConverter(typeof(IanaTimeZoneJsonConverter))]
-    public TimeZoneInfo? Timezone { get; set; }
+    public TimeZoneInfo? Timezone { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Search/Endpoints/SearchCategories/SearchCategoriesRequest.cs
+++ b/TwitchySharp.Api/Helix/Search/Endpoints/SearchCategories/SearchCategoriesRequest.cs
@@ -23,8 +23,6 @@ public record SearchCategoriesRequest
 {
     protected override string Path => "/search/categories";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("query", Query)
@@ -34,7 +32,7 @@ public record SearchCategoriesRequest
     /// <summary>
     /// The search string.
     /// </summary>
-    public required string Query { get; set; }
+    public required string Query { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -43,8 +41,8 @@ public record SearchCategoriesRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Search/Endpoints/SearchChannels/SearchChannelsRequest.cs
+++ b/TwitchySharp.Api/Helix/Search/Endpoints/SearchChannels/SearchChannelsRequest.cs
@@ -18,8 +18,6 @@ public record SearchChannelsRequest
 {
     protected override string Path => "/search/channels";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("query", Query)
@@ -36,7 +34,7 @@ public record SearchChannelsRequest
     /// If query is <c>"angel_of_death"</c>, it matches all names that begin with angel_of_death.
     /// However, if query is a phrase like <c>"angel of death"</c>, it matches to names starting with angelofdeath or names starting with angel_of_death.
     /// </remarks>
-    public required string Query { get; set; }
+    public required string Query { get; init; }
 
     /// <summary>
     /// Determines whether the response includes only channels that are currently streaming live.
@@ -47,7 +45,7 @@ public record SearchChannelsRequest
     /// If it is <see langword="false"/>, the API matches on the broadcaster's login (username).
     /// However, if it is <see langword="true"/>, the API matches on the broadcaster's name and category name.
     /// </remarks>
-    public bool? LiveOnly { get; set; }
+    public bool? LiveOnly { get; init; }
 
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
@@ -56,8 +54,8 @@ public record SearchChannelsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
 
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Streams/Endpoints/CreateStreamMarker/CreateStreamMarkerRequest.cs
+++ b/TwitchySharp.Api/Helix/Streams/Endpoints/CreateStreamMarker/CreateStreamMarkerRequest.cs
@@ -42,7 +42,7 @@ public record CreateStreamMarkerRequest
     /// <summary>
     /// The marker to create.
     /// </summary>
-    public required CreateStreamMarkerRequestData Marker { get; set; }
+    public required CreateStreamMarkerRequestData Marker { get; init; }
 }
 
 /// <summary>
@@ -54,10 +54,10 @@ public record CreateStreamMarkerRequestData
     /// The user id of the broadcaster to create a marker for.
     /// This user or one of this broadcaster's editors must have created the user access token used in the <see cref="CreateStreamMarkerRequest"/>.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
     /// <summary>
     /// A short description of the marker to help the user remember why they marked the location. 
     /// The maximum length of the description is 140 characters.
     /// </summary>
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Streams/Endpoints/GetFollowedStreams/GetFollowedStreamsRequest.cs
+++ b/TwitchySharp.Api/Helix/Streams/Endpoints/GetFollowedStreams/GetFollowedStreamsRequest.cs
@@ -33,7 +33,7 @@ public record GetFollowedStreamsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -41,7 +41,7 @@ public record GetFollowedStreamsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 100.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreamKey/GetStreamKeyRequest.cs
+++ b/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreamKey/GetStreamKeyRequest.cs
@@ -30,5 +30,5 @@ public record GetStreamKeyRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreamMarkers/GetStreamMarkersRequest.cs
+++ b/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreamMarkers/GetStreamMarkersRequest.cs
@@ -33,7 +33,7 @@ public record GetStreamMarkersRequest
     /// <summary>
     /// The user to get stream markers as (broadcaster or editor).
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The user id of the broadcaster to get markers for.
@@ -43,7 +43,7 @@ public record GetStreamMarkersRequest
     /// <remarks>
     /// Mutually exclusive with <see cref="VideoId"/>. One of <see cref="UserId"/> or <see cref="VideoId"/> must be set.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
     /// <summary>
     /// The video id of the video to get markers for.
     /// If set, the request will return marks from this specific video.
@@ -52,7 +52,7 @@ public record GetStreamMarkersRequest
     /// <remarks>
     /// Mutually exclusive with <see cref="UserId"/>. One of <see cref="UserId"/> or <see cref="VideoId"/> must be set.
     /// </remarks>
-    public VideoId? VideoId { get; set; }
+    public VideoId? VideoId { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -60,11 +60,11 @@ public record GetStreamMarkersRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreams/GetStreamsRequest.cs
+++ b/TwitchySharp.Api/Helix/Streams/Endpoints/GetStreams/GetStreamsRequest.cs
@@ -22,8 +22,6 @@ public record GetStreamsRequest
 {
     protected override string Path => "/streams";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("user_id", UserIds?.Select(x => x.Value))
@@ -40,31 +38,31 @@ public record GetStreamsRequest
     /// Returns only the streams of those users that are broadcasting.
     /// You may specify a maximum of 100 ids.
     /// </summary>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
     /// <summary>
     /// A list of user logins (usernames) used to filter the list of streams.
     /// Returns only the streams of those users that are broadcasting.
     /// You may specify a maximum of 100 login names.
     /// </summary>
-    public IEnumerable<UserLogin>? UserLogins { get; set; }
+    public IEnumerable<UserLogin>? UserLogins { get; init; }
     /// <summary>
     /// A game (category) id used to filter the list of streams.
     /// Returns only the streams that are broadcasting the game (category).
     /// You may specify a maximum of 100 ids.
     /// </summary>
-    public IEnumerable<GameId>? GameIds { get; set; }
+    public IEnumerable<GameId>? GameIds { get; init; }
     /// <summary>
     /// The type of stream to filter the list of streams by.
     /// The default is <see cref="StreamType.All"/>.
     /// </summary>
-    public StreamType? Type { get; set; }
+    public StreamType? Type { get; init; }
     /// <summary>
     /// A language code used to filter the list of streams.
     /// Returns only streams that broadcast in the specified language.
     /// Specify the language using an ISO 639-1 two-letter language code or other if the broadcast uses a language not in the list of <see href="https://help.twitch.tv/s/article/languages-on-twitch#streamlang">supported stream languages</see>.
     /// You may specify a maximum of 100 language codes.
     /// </summary>
-    public IEnumerable<LanguageCode>? Languages { get; set; }
+    public IEnumerable<LanguageCode>? Languages { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -72,11 +70,11 @@ public record GetStreamsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Subscriptions/Endpoints/CheckUserSubscription/CheckUserSubscriptionRequest.cs
+++ b/TwitchySharp.Api/Helix/Subscriptions/Endpoints/CheckUserSubscription/CheckUserSubscriptionRequest.cs
@@ -30,12 +30,12 @@ public record CheckUserSubscriptionRequest
     /// <summary>
     /// The user id of the broadcaster that the subscription is to.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The id of the user to get the subscription for.
     /// </summary>
     /// <remarks>
     /// This must be the same user that created the access token.
     /// </remarks>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Subscriptions/Endpoints/GetBroadcasterSubscriptions/GetBroadcasterSubscriptionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Subscriptions/Endpoints/GetBroadcasterSubscriptions/GetBroadcasterSubscriptionsRequest.cs
@@ -37,14 +37,14 @@ public record GetBroadcasterSubscriptionsRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// Filter the list of subscribers by user id.
     /// </summary>
     /// <remarks>
     /// You may specify a maximum of 100 subscribers.
     /// </remarks>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -52,7 +52,7 @@ public record GetBroadcasterSubscriptionsRequest
     /// The minimum page size is 1 item per page and the maximum is 100 items per page.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
@@ -60,7 +60,7 @@ public record GetBroadcasterSubscriptionsRequest
     /// Do not specify if you set <see cref="UserIds"/>.
     /// The <see cref="Pagination"/> object in the response contains the cursor's value.
     /// </remarks>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
     /// <summary>
     /// <inheritdoc cref="IPageableRequest.After"/>
     /// </summary>
@@ -68,5 +68,5 @@ public record GetBroadcasterSubscriptionsRequest
     /// <inheritdoc cref="IPageableRequest.After"/>
     /// Do not specify if you set <see cref="UserIds"/>.
     /// </remarks>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Teams/Endpoints/GetChannelTeams/GetChannelTeamsRequest.cs
+++ b/TwitchySharp.Api/Helix/Teams/Endpoints/GetChannelTeams/GetChannelTeamsRequest.cs
@@ -18,8 +18,6 @@ public record GetChannelTeamsRequest
 {
     protected override string Path => "/teams/channel";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("broadcaster_id", BroadcasterId);
@@ -27,5 +25,5 @@ public record GetChannelTeamsRequest
     /// <summary>
     /// The user id of the broadcaster to get teams for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Teams/Endpoints/GetTeams/GetTeamsRequest.cs
+++ b/TwitchySharp.Api/Helix/Teams/Endpoints/GetTeams/GetTeamsRequest.cs
@@ -18,8 +18,6 @@ public record GetTeamsRequest
 {
     protected override string Path => "/teams";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("name", Query.Name)
@@ -31,7 +29,7 @@ public record GetTeamsRequest
     /// <remarks>
     /// Use <see cref="TeamsQueryByName"/> or <see cref="TeamsQueryById"/>.
     /// </remarks>
-    public required TeamsQuery Query { get; set; }
+    public required TeamsQuery Query { get; init; }
 }
 
 /// <summary>

--- a/TwitchySharp.Api/Helix/TwitchHelixRequest.cs
+++ b/TwitchySharp.Api/Helix/TwitchHelixRequest.cs
@@ -22,7 +22,7 @@ public abstract record TwitchHelixRequest<TResponseContent>
         init => _configuredIdentity = value;
     }
     private TwitchApiIdentity? _configuredIdentity;
-    protected abstract TwitchApiIdentity DefaultIdentity { get; }
+    protected virtual TwitchApiIdentity DefaultIdentity { get; } = TwitchApiIdentity.Default;
     public virtual IEnumerable<Scope> ValidScopes { get; } = [];
     public virtual AccessToken? OverrideAccessToken { get; init; }
     protected virtual HttpQueryParameters? QueryParameters { get; }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/BlockUser/BlockUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/BlockUser/BlockUserRequest.cs
@@ -30,7 +30,7 @@ public record BlockUserRequest
     /// <summary>
     /// The user to block the target user as.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The id of the user to block.
@@ -38,13 +38,13 @@ public record BlockUserRequest
     /// <remarks>
     /// If the user is already blocked, the request is ignored.
     /// </remarks>
-    public required UserId TargetUserId { get; set; }
+    public required UserId TargetUserId { get; init; }
     /// <summary>
     /// The location where the harassment took place that is causing the brodcaster to block the user.
     /// </summary>
-    public BlockUserContext? SourceContext { get; set; }
+    public BlockUserContext? SourceContext { get; init; }
     /// <summary>
     /// The reason that the broadcaster is blocking the user.
     /// </summary>
-    public BlockUserReason? Reason { get; set; }
+    public BlockUserReason? Reason { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/GetUserActiveExtensions/GetUserActiveExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/GetUserActiveExtensions/GetUserActiveExtensionsRequest.cs
@@ -21,7 +21,6 @@ public record GetUserActiveExtensionsRequest
 {
     protected override string Path => "/users/extensions";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
     public override IEnumerable<Scope> ValidScopes => [ Scope.UserReadBroadcast, Scope.UserEditBroadcast ];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
@@ -30,7 +29,7 @@ public record GetUserActiveExtensionsRequest
     /// <summary>
     /// The user id of the broadcaster to get active extensions for.
     /// </summary>
-    public required UserId UserId { get; set; }
+    public required UserId UserId { get; init; }
 
     /// <summary>
     /// Returns a new request configured to include extensions that are under development.

--- a/TwitchySharp.Api/Helix/Users/Endpoints/GetUserBlockList/GetUserBlockListRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/GetUserBlockList/GetUserBlockListRequest.cs
@@ -32,7 +32,7 @@ public record GetUserBlockListRequest
     /// <remarks>
     /// This must be the same user that created the access token in the request.
     /// </remarks>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -40,7 +40,7 @@ public record GetUserBlockListRequest
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/GetUserExtensions/GetUserExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/GetUserExtensions/GetUserExtensionsRequest.cs
@@ -25,5 +25,5 @@ public record GetUserExtensionsRequest
     /// <summary>
     /// The user to get extensions for.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/GetUsers/GetUsersRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/GetUsers/GetUsersRequest.cs
@@ -26,7 +26,6 @@ public record GetUsersRequest
 {
     protected override string Path => "/users";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
     private IEnumerable<Scope> ConfiguredScopes { get; init; } = [];
     public override IEnumerable<Scope> ValidScopes => ConfiguredScopes;
     protected override HttpQueryParameters QueryParameters
@@ -40,14 +39,14 @@ public record GetUsersRequest
     /// <remarks>
     /// You may specify a maximum of 100 ids total between <see cref="UserIds"/> and <see cref="UserLogins"/>.
     /// </remarks>
-    public IEnumerable<UserId>? UserIds { get; set; }
+    public IEnumerable<UserId>? UserIds { get; init; }
     /// <summary>
     /// The logins (usernames) of the users to get.
     /// </summary>
     /// <remarks>
     /// You may specify a maximum of 100 logins total between <see cref="UserIds"/> and <see cref="UserLogins"/>.
     /// </remarks>
-    public IEnumerable<UserLogin>? UserLogins { get; set; }
+    public IEnumerable<UserLogin>? UserLogins { get; init; }
 
     /// <summary>
     /// Returns a new request configured to include the user's email in the response.

--- a/TwitchySharp.Api/Helix/Users/Endpoints/UnblockUser/UnblockUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/UnblockUser/UnblockUserRequest.cs
@@ -29,7 +29,7 @@ public record UnblockUserRequest
     /// <summary>
     /// The user to unblock the target user as.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The id of the user to remove from the broadcaster's list of blocked users.
@@ -37,5 +37,5 @@ public record UnblockUserRequest
     /// <remarks>
     /// The API ignores the request if the broadcaster hasn't blocked the user.
     /// </remarks>
-    public required UserId TargetUserId { get; set; }
+    public required UserId TargetUserId { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUser/UpdateUserRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUser/UpdateUserRequest.cs
@@ -28,7 +28,7 @@ public record UpdateUserRequest
     /// <summary>
     /// The user to update.
     /// </summary>
-    public required UserIdentity User { get; set; }
+    public required UserIdentity User { get; init; }
 
     /// <summary>
     /// The string to update the channel's description to.
@@ -37,5 +37,5 @@ public record UpdateUserRequest
     /// The description is limited to a maximum of 300 characters.
     /// To remove the description, set this to <see cref="string.Empty"/>.
     /// </remarks>
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUserExtensions/UpdateUserExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUserExtensions/UpdateUserExtensionsRequest.cs
@@ -24,6 +24,13 @@ public record UpdateUserExtensionsRequest
     protected override string Path => "/users/extensions";
     public override HttpMethod Method => HttpMethod.Put;
     public override IEnumerable<Scope> ValidScopes => [ Scope.UserEditBroadcast ];
+    protected override TwitchApiIdentity DefaultIdentity => User;
+
+    /// <summary>
+    /// The user identity of the broadcaster whose extensions will be updated.
+    /// </summary>
+    public required UserIdentity User { get; init; }
+
     // Note: Unsure of how this function actually behaves. I'm assuming only included extensions are updated, but if all extensions are updated, this could delete extensions.
     // Class may need to be re-written during testing because of how crap the docs are for this one. Very strange models as well.
     public override object? ContentObject => new UpdateUserExtensionsRequestData(Extensions);

--- a/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUserExtensions/UpdateUserExtensionsRequest.cs
+++ b/TwitchySharp.Api/Helix/Users/Endpoints/UpdateUserExtensions/UpdateUserExtensionsRequest.cs
@@ -23,7 +23,6 @@ public record UpdateUserExtensionsRequest
 {
     protected override string Path => "/users/extensions";
     public override HttpMethod Method => HttpMethod.Put;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
     public override IEnumerable<Scope> ValidScopes => [ Scope.UserEditBroadcast ];
     // Note: Unsure of how this function actually behaves. I'm assuming only included extensions are updated, but if all extensions are updated, this could delete extensions.
     // Class may need to be re-written during testing because of how crap the docs are for this one. Very strange models as well.
@@ -32,7 +31,7 @@ public record UpdateUserExtensionsRequest
     /// <summary>
     /// The extensions to update.
     /// </summary>
-    public required ExtensionsConfiguration Extensions { get; set; }
+    public required ExtensionsConfiguration Extensions { get; init; }
 }
 
 /// <summary>
@@ -40,7 +39,7 @@ public record UpdateUserExtensionsRequest
 /// </summary>
 internal record UpdateUserExtensionsRequestData
 {
-    public UpdateUserExtensionsMaps Data { get; set; }
+    public UpdateUserExtensionsMaps Data { get; init; }
     public UpdateUserExtensionsRequestData(ExtensionsConfiguration extensions)
         => Data = new UpdateUserExtensionsMaps()
         {
@@ -155,15 +154,15 @@ public record ExtensionsConfiguration
     /// <summary>
     /// The panel extensions to update.
     /// </summary>
-    public ExtensionsConfigurationType<UpdateExtensionParameters>? PanelExtensions { get; set; }
+    public ExtensionsConfigurationType<UpdateExtensionParameters>? PanelExtensions { get; init; }
     /// <summary>
     /// The overlay extensions to update.
     /// </summary>
-    public ExtensionsConfigurationType<UpdateExtensionParameters>? OverlayExtensions { get; set; }
+    public ExtensionsConfigurationType<UpdateExtensionParameters>? OverlayExtensions { get; init; }
     /// <summary>
     /// The component extensions to update.
     /// </summary>
-    public ExtensionsConfigurationType<UpdateComponentExtensionParameters>? ComponentExtensions { get; set; }
+    public ExtensionsConfigurationType<UpdateComponentExtensionParameters>? ComponentExtensions { get; init; }
 }
 
 /// <summary>
@@ -221,7 +220,7 @@ public record UpdateExtensionParameters
     /// <summary>
     /// Determines the extension’s activation state
     /// </summary>
-    public required bool Active { get; set; }
+    public required bool Active { get; init; }
 }
 
 /// <summary>
@@ -233,9 +232,9 @@ public record UpdateComponentExtensionParameters
     /// <summary>
     /// The x-coordinate of the extension.
     /// </summary>
-    public int? X { get; set; }
+    public int? X { get; init; }
     /// <summary>
     /// The y- coordinate of the extension.
     /// </summary>
-    public int? Y { get; set; }
+    public int? Y { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Videos/Endpoints/CreateClipFromVod/CreateClipFromVodRequest.cs
+++ b/TwitchySharp.Api/Helix/Videos/Endpoints/CreateClipFromVod/CreateClipFromVodRequest.cs
@@ -39,15 +39,15 @@ public record CreateClipFromVodRequest
     /// This should be the same user that created the user access token in the request,
     /// and it can be the broadcaster.
     /// </summary>
-    public required UserId EditorId { get; set; }
+    public required UserId EditorId { get; init; }
     /// <summary>
     /// The user id of the broadcaster (channel) to create a clip for.
     /// </summary>
-    public required UserId BroadcasterId { get; set; }
+    public required UserId BroadcasterId { get; init; }
     /// <summary>
     /// The id of the VOD to create a clip for.
     /// </summary>
-    public required VideoId VodId { get; set; }
+    public required VideoId VodId { get; init; }
     /// <summary>
     /// The end time of clip to create, measured from the start of the VOD.
     /// </summary>
@@ -55,7 +55,7 @@ public record CreateClipFromVodRequest
     /// The clip will start at <c><see cref="VodOffset"/> - <see cref="Duration"/></c>.
     /// If <see cref="Duration"/> is specified, this must be greater than its value.
     /// </remarks>
-    public required TimeSpan VodOffset { get; set; }
+    public required TimeSpan VodOffset { get; init; }
     /// <summary>
     /// The duration of the clip to create.
     /// </summary>
@@ -63,9 +63,9 @@ public record CreateClipFromVodRequest
     /// Can range from 5 to 60 seconds, with a resolution of 100ms.
     /// If left <see langword="null"/>, defaults to 30 seconds.
     /// </remarks>
-    public TimeSpan? Duration { get; set; }
+    public TimeSpan? Duration { get; init; }
     /// <summary>
     /// The title of the clip to create.
     /// </summary>
-    public required string Title { get; set; }
+    public required string Title { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Videos/Endpoints/DeleteVideos/DeleteVideosRequest.cs
+++ b/TwitchySharp.Api/Helix/Videos/Endpoints/DeleteVideos/DeleteVideosRequest.cs
@@ -21,7 +21,6 @@ public record DeleteVideosRequest
 {
     protected override string Path => "/videos";
     public override HttpMethod Method => HttpMethod.Delete;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
     public override IEnumerable<Scope> ValidScopes => [ Scope.ChannelManageVideos ];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
@@ -34,5 +33,5 @@ public record DeleteVideosRequest
     /// You can delete a maximum of 5 videos per request. Ignores invalid video IDs.
     /// If the user doesn't have permission to delete one of the videos in the list, none of the videos are deleted.
     /// </remarks>
-    public required IEnumerable<VideoId> Ids { get; set; }
+    public required IEnumerable<VideoId> Ids { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Videos/Endpoints/DeleteVideos/DeleteVideosRequest.cs
+++ b/TwitchySharp.Api/Helix/Videos/Endpoints/DeleteVideos/DeleteVideosRequest.cs
@@ -22,6 +22,13 @@ public record DeleteVideosRequest
     protected override string Path => "/videos";
     public override HttpMethod Method => HttpMethod.Delete;
     public override IEnumerable<Scope> ValidScopes => [ Scope.ChannelManageVideos ];
+    protected override TwitchApiIdentity DefaultIdentity => User;
+
+    /// <summary>
+    /// The user identity of the broadcaster who owns the videos to delete.
+    /// </summary>
+    public required UserIdentity User { get; init; }
+
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", Ids.Select(x => x.Value));

--- a/TwitchySharp.Api/Helix/Videos/Endpoints/GetVideos/GetVideosRequest.cs
+++ b/TwitchySharp.Api/Helix/Videos/Endpoints/GetVideos/GetVideosRequest.cs
@@ -22,8 +22,6 @@ public record GetVideosRequest
 {
     protected override string Path => "/videos";
     public override HttpMethod Method => HttpMethod.Get;
-    protected override TwitchApiIdentity DefaultIdentity => TwitchApiIdentity.Default;
-    public override IEnumerable<Scope> ValidScopes => [];
     protected override HttpQueryParameters QueryParameters
         => new HttpQueryParameters()
             .Add("id", Ids?.Select(x => x.Value))
@@ -45,21 +43,21 @@ public record GetVideosRequest
     /// You may specify a maximum of 100 ids.
     /// The API ignores duplicate ids and ids that weren't found (if there's at least one valid id).
     /// </remarks>
-    public IEnumerable<VideoId>? Ids { get; set; }
+    public IEnumerable<VideoId>? Ids { get; init; }
     /// <summary>
     /// The user id of the broadcaster whose list of videos you want to get.
     /// </summary>
     /// <remarks>
     /// Mutually exclusive with <see cref="Ids"/> and <see cref="GameId"/>.
     /// </remarks>
-    public UserId? UserId { get; set; }
+    public UserId? UserId { get; init; }
     /// <summary>
     /// The id of the game or category you want to get videos for.
     /// </summary>
     /// <remarks>
     /// Mutually exclusive with <see cref="Ids"/> and <see cref="UserId"/>.
     /// </remarks>
-    public GameId? GameId { get; set; }
+    public GameId? GameId { get; init; }
     /// <summary>
     /// An ISO 639-1 two-letter code to filter returned videos by.
     /// </summary>
@@ -68,7 +66,7 @@ public record GetVideosRequest
     /// For a list of supported languages, see <see href="https://help.twitch.tv/s/article/languages-on-twitch#streamlang">Supported Stream Language</see>.
     /// If the language is not supported, use <see cref="LanguageCode.Other"/>.
     /// </remarks>
-    public LanguageCode? Language { get; set; }
+    public LanguageCode? Language { get; init; }
     /// <summary>
     /// Filters the returned list of videos by when they were published.
     /// </summary>
@@ -76,7 +74,7 @@ public record GetVideosRequest
     /// Only applicable when querying by <see cref="UserId"/> or <see cref="GameId"/>.
     /// Defaults to <see cref="VideoQueryPeriod.All"/>.
     /// </remarks>
-    public VideoQueryPeriod? Period { get; set; }
+    public VideoQueryPeriod? Period { get; init; }
     /// <summary>
     /// The sort order to return the videos in.
     /// </summary>
@@ -84,7 +82,7 @@ public record GetVideosRequest
     /// Only applicable when querying by <see cref="UserId"/> or <see cref="GameId"/>.
     /// Defaults to <see cref="VideoQuerySort.Time"/>.
     /// </remarks>
-    public VideoQuerySort? Sort { get; set; }
+    public VideoQuerySort? Sort { get; init; }
     /// <summary>
     /// Filters the returned list of videos by type.
     /// </summary>
@@ -92,7 +90,7 @@ public record GetVideosRequest
     /// Only applicable when querying by <see cref="UserId"/> or <see cref="GameId"/>.
     /// Defaults to <see cref="VideoQueryType.All"/>.
     /// </remarks>
-    public VideoQueryType? Type { get; set; }
+    public VideoQueryType? Type { get; init; }
     /// <summary>
     /// <inheritdoc cref="PaginationAmount"/>
     /// </summary>
@@ -101,11 +99,11 @@ public record GetVideosRequest
     /// The minimum page size is 1 item per page and the maximum is 100.
     /// The default is 20.
     /// </remarks>
-    public PaginationAmount? First { get; set; }
+    public PaginationAmount? First { get; init; }
     /// <inheritdoc/>
-    public PaginationCursor? After { get; set; }
+    public PaginationCursor? After { get; init; }
     /// <summary>
     /// The cursor of the result to get results before.
     /// </summary>
-    public PaginationCursor? Before { get; set; }
+    public PaginationCursor? Before { get; init; }
 }

--- a/TwitchySharp.Api/Helix/Whispers/Endpoints/SendWhisper/SendWhisperRequest.cs
+++ b/TwitchySharp.Api/Helix/Whispers/Endpoints/SendWhisper/SendWhisperRequest.cs
@@ -44,15 +44,15 @@ public record SendWhisperRequest
     /// <remarks>
     /// This must be the same user that created the access token used in the request.
     /// </remarks>
-    public required UserId FromUserId { get; set; }
+    public required UserId FromUserId { get; init; }
     /// <summary>
     /// The id of the user receiving the whisper.
     /// </summary>
-    public required UserId ToUserId { get; set; }
+    public required UserId ToUserId { get; init; }
     /// <summary>
     /// The whisper content to send.
     /// </summary>
-    public required SendWhisperRequestData Whisper { get; set; }
+    public required SendWhisperRequestData Whisper { get; init; }
 }
 
 /// <summary>
@@ -68,5 +68,5 @@ public record SendWhisperRequestData
     /// The message can be up to 10,000 characters if the to user has whispered the from user before, otherwise, the message can only be 500 characters long.
     /// Messages that exceed the maximum length are truncated.
     /// </remarks>
-    public required string Message { get; set; }
+    public required string Message { get; init; }
 }

--- a/TwitchySharp.Api/Models/DateTimeOffsetRange.cs
+++ b/TwitchySharp.Api/Models/DateTimeOffsetRange.cs
@@ -7,7 +7,7 @@ namespace TwitchySharp.Api;
 public record struct DateTimeOffsetRange
 {
     [JsonInclude, JsonRequired, JsonConverter(typeof(EmptyDateTimeOffsetConverter))]
-    public DateTimeOffset? StartedAt { get; private set; }
+    public DateTimeOffset? StartedAt { get; private init; }
     [JsonInclude, JsonRequired, JsonConverter(typeof(EmptyDateTimeOffsetConverter))]
-    public DateTimeOffset? EndedAt { get; private set; }
+    public DateTimeOffset? EndedAt { get; private init; }
 }

--- a/TwitchySharp.Api/Models/Pagination.cs
+++ b/TwitchySharp.Api/Models/Pagination.cs
@@ -58,9 +58,9 @@ public interface IPageableRequest
     /// This value can be obtained from a <see cref="Pagination"/> object inside of a <see cref="IPageableResponse"/>.
     /// Set this value to that value to get the next page of results.
     /// </remarks>
-    PaginationCursor? After { get; set; }
+    PaginationCursor? After { get; init; }
     /// <summary>
     /// The maximum number of results to include per page in the response.
     /// </summary>
-    PaginationAmount? First { get; set; }
+    PaginationAmount? First { get; init; }
 }


### PR DESCRIPTION
## Summary
- Enforces immutable design pattern across all request types and data objects
- Removes redundant empty `ValidScopes` declarations
- Ensures all pageable requests implement `IPageableRequest`

## Changes

### Immutability (#38)
- Changed all `{ get; set; }` to `{ get; init; }` on request types and their nested data objects
- Changed `{ get; private set; }` and `{ get; protected set; }` to init variants  
- Refactored fluent methods to use `with` expressions instead of mutation:
  - `GetGameAnalyticsRequest.WithinDateRange`
  - `GetExtensionAnalyticsRequest.WithinDateRange`
  - `GetExtensionConfigurationSegmentRequest.Add*` methods (now uses `ImmutableHashSet`)
- Updated derived transport types to use init accessors

### ValidScopes cleanup (#39)
- Removed 46 redundant `ValidScopes => []` declarations
- Base `TwitchHelixRequest` already provides virtual default returning empty collection

### IPageableRequest (#40)
- Updated `IPageableRequest` interface to use `init;` setters
- Added missing implementations to:
  - `GetGameAnalyticsRequest`
  - `GetUserEmotesRequest`

## Testing
- All 29 unit tests pass
- Build succeeds with no warnings

Closes #38, Closes #39, Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)